### PR TITLE
Added workingDir parameter

### DIFF
--- a/vars/openShift.groovy
+++ b/vars/openShift.groovy
@@ -13,6 +13,7 @@ def withNode(parameters = [:], Closure body = null) {
     limitMemory = parameters.get('resourceLimitMemory', "650Mi")
     cloud = parameters.get('cloud', "openshift")
     yaml = parameters.get('yaml')
+    workingDir = parameters.get('workingDir', "/home/jenkins")
 
     label = "test-${UUID.randomUUID().toString()}"
 
@@ -36,6 +37,7 @@ def withNode(parameters = [:], Closure body = null) {
                 resourceLimitCpu: limitCpu,
                 resourceRequestMemory: requestMemory,
                 resourceLimitMemory: limitMemory,
+                workingDir: workingDir,
                 envVars: [
                     envVar(key: 'LC_ALL', value: 'en_US.utf-8'),
                     envVar(key: 'LANG', value: 'en_US.utf-8'),


### PR DESCRIPTION
Our jenkins slave image has installed virtualenv in `/home/jenkins`. By default the jenkins slave uses that path and when a container is spawned everything in that dir is cleaned. I found a workaround for that where you need to specify just an empty string as a path.