### PR TITLE
/dev/shm mounted to emptyDir

### DIFF
--- a/vars/openShift.groovy
+++ b/vars/openShift.groovy
@@ -78,6 +78,9 @@ def withUINode(Map parameters = [:], Closure body = null) {
                 image: pipelineVars.seleniumImage,
                 workingDir: ''
             ),
+        ],
+        volumes: [
+            emptyDirVolume(mountPath: '/dev/shm', memory: false),
         ]
     ]
 


### PR DESCRIPTION
It should fix occasional browser crashes. Cost management team have been using this fix for three days and hasn't faced any crashes.