### PR TITLE
Allow params injection

### DIFF
--- a/vars/deploymentPipeline.groovy
+++ b/vars/deploymentPipeline.groovy
@@ -42,8 +42,9 @@ private def parseParams(envs, svcs) {
 def call(p = [:]) {
     envs = p['environments']
     svcs = p['services']
+    extraParams = p['extraParams'] ?: []
 
-    properties([parameters(getJobParams(envs, svcs))])
+    properties([parameters(getJobParams(envs, svcs) + extraParams)])
     parsed = parseParams(envs, svcs)
     imagesToCopy = parsed['imagesToCopy']
     servicesToSkip = parsed['servicesToSkip']


### PR DESCRIPTION
This should allow me to inject preset params to the `deploymentPipeline` process. That can allow me to set services and environments dynamically. I'm not sure this is the correct way to do it, I'm no groovy expert, so please, @bsquizz, correct me if I'm wrong.

I've tried it here: https://jenkins-jenkins.5a9f.insights-dev.openshiftapps.com/job/ops/job/deployAiops/
It loaded the params properly, however it failed right after. Not sure what happened there, if I've butchered something or it's just a sandbox issue...

Required for https://github.com/RedHatInsights/e2e-deploy/pull/208