### PR TITLE
Add catalog, approval, sources, and topo to the deployHelper

### DIFF
--- a/vars/deployHelpers.groovy
+++ b/vars/deployHelpers.groovy
@@ -11,7 +11,11 @@ import groovy.transform.Field
 @Field deployJobs = [
     buildfactory: "/ops/deployBuildfactory",
     advisor: "/ops/deployAdvisor",
+    approval: "/ops/deployApproval",
+    catalog: "/ops/deployCatalog",
     platform: "/ops/deployPlatform",
+    sources: "/ops/deploySources",
+    "topological-inventory": "/ops/deployTopologicalInventory",
 ]
 
 


### PR DESCRIPTION
@bsquizz please review

I'm not sure if `topological-inventory` is a legal move for a key here, but I'm not sure what else would work if it has to match the service set name.