### PR TITLE
Add the ability to trigger a smoke test manually

### DIFF
--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -42,12 +42,12 @@ def call(parameters = [:]) {
 
     // Define a string parameter to set the git ref on manual runs
     properties([parameters(
-        [
+        [[
             $class: 'StringParameterDefinition',
             name: 'GIT_REF',
             defaultValue: 'master',
             description: 'The git ref to deploy for this app during the smoke test'
-        ]
+        ]]
     )])
 
     // If testing via a PR webhook trigger

--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -103,7 +103,7 @@ private def runPipeline(
 
     // check out e2e-deploy
     stage("Check out repos") {
-        checkOutRepo(targetDir: pipelineVars.e2eDeployDir, repoUrl: pipelineVars.e2eDeployRepo)
+        checkOutRepo(targetDir: pipelineVars.e2eDeployDir, repoUrl: pipelineVars.e2eDeployRepo, credentialsId: "InsightsDroidGitHubHTTP")
     }
 
     stage("Install ocdeployer") {

--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -42,12 +42,11 @@ def call(parameters = [:]) {
 
     // Define a string parameter to set the git ref on manual runs
     properties([parameters(
-        [[
-            $class: 'StringParameterDefinition',
+        [string(
             name: 'GIT_REF',
             defaultValue: 'master',
             description: 'The git ref to deploy for this app during the smoke test'
-        ]]
+        )]
     )])
 
     // If testing via a PR webhook trigger

--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -42,11 +42,11 @@ def call(parameters = [:]) {
 
     // Define a string parameter to set the git ref on manual runs
     properties([parameters(
-        [string(
+        string(
             name: 'GIT_REF',
             defaultValue: 'master',
             description: 'The git ref to deploy for this app during the smoke test'
-        )]
+        )
     )])
 
     // If testing via a PR webhook trigger

--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -34,23 +34,26 @@
 
 
 private def getRefSpec() {
-    // cache creds so we can git 'ls-remote' below...
-    sh "git config --global credential.helper cache"
-    
     def refSpec
-    sh "mkdir pr_source"
-    
-    dir("pr_source") {
-        checkout scm
 
-        // get refspec so we can set up the OpenShift build config to point to this PR
-        // there's gotta be a better way to get the refspec, somehow 'checkout scm' knows what it is ...
+    // Need to allocate a node to store the source code ...
+    node {
+        // cache creds so we can git 'ls-remote' below...
+        sh "git config --global credential.helper cache"
+        sh "mkdir pr_source"
+        
+        dir("pr_source") {
+            checkout scm
 
-        stage("Get refspec") {
-            refSpec = "refs/pull/${env.CHANGE_ID}/merge"
-            def refspecExists = sh(returnStdout: true, script: "git ls-remote | grep ${refSpec}").trim()
-            if (!refspecExists) {
-                error("Unable to find git refspec: ${refSpec}")
+            // get refspec so we can set up the OpenShift build config to point to this PR
+            // there's gotta be a better way to get the refspec, somehow 'checkout scm' knows what it is ...
+
+            stage("Get refspec") {
+                refSpec = "refs/pull/${env.CHANGE_ID}/merge"
+                def refspecExists = sh(returnStdout: true, script: "git ls-remote | grep ${refSpec}").trim()
+                if (!refspecExists) {
+                    error("Unable to find git refspec: ${refSpec}")
+                }
             }
         }
     }

--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -41,13 +41,15 @@ def call(p = [:]) {
     def extraEnvVars = p.get('extraEnvVars', [:])
 
     // Define a string parameter to set the git ref on manual runs
-    properties([parameters([
-        string(
-            name: 'GIT_REF',
-            defaultValue: 'master',
-            description: 'The git ref to deploy for this app during the smoke test'
-        ])
-    )])
+    properties(
+        [parameters([
+            string(
+                name: 'GIT_REF',
+                defaultValue: 'master',
+                description: 'The git ref to deploy for this app during the smoke test'
+            )
+        ])]
+    )
 
     // If testing via a PR webhook trigger
     if (env.CHANGE_ID) {

--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -32,21 +32,21 @@
  *
  */
 
-def call(parameters = [:]) {
-    def ocDeployerBuilderPath = parameters['ocDeployerBuilderPath']
-    def ocDeployerComponentPath = parameters['ocDeployerComponentPath']
-    def ocDeployerServiceSets = parameters['ocDeployerServiceSets']
-    def pytestMarker = parameters['pytestMarker']
-    def iqePlugins = parameters.get('iqePlugins')
-    def extraEnvVars = parameters.get('extraEnvVars', [:])
+def call(p = [:]) {
+    def ocDeployerBuilderPath = p['ocDeployerBuilderPath']
+    def ocDeployerComponentPath = p['ocDeployerComponentPath']
+    def ocDeployerServiceSets = p['ocDeployerServiceSets']
+    def pytestMarker = p['pytestMarker']
+    def iqePlugins = p.get('iqePlugins')
+    def extraEnvVars = p.get('extraEnvVars', [:])
 
     // Define a string parameter to set the git ref on manual runs
-    properties([parameters(
+    properties([parameters([
         string(
             name: 'GIT_REF',
             defaultValue: 'master',
             description: 'The git ref to deploy for this app during the smoke test'
-        )
+        ])
     )])
 
     // If testing via a PR webhook trigger


### PR DESCRIPTION
This will add a job parameter that allows you to set the git commit/branch you want to run a smoke test on. Then you can manually fire off a smoke test without it being triggered by a GitHub PR.