### PR TITLE
Set version of pipenv to 2018.10.13 because of a bug in pipenv

### DIFF
--- a/vars/runPipenvInstall.groovy
+++ b/vars/runPipenvInstall.groovy
@@ -10,7 +10,8 @@ def call(parameters = [:]) {
     def lockErrorRegex = ~/.*Your Pipfile.lock \(\S+\) is out of date. Expected: \(\S+\).*/
     def lockError = "\n* `Pipfile.lock` is out of sync. Run '`pipenv lock`' and commit the changes."
     def installError = "\n* '`pipenv install`' has failed."
-
+    
+    // Modified version to pipenv because of https://github.com/pypa/pipenv/issues/3560
     sh "pip install --user --upgrade pip setuptools wheel pipenv"
     // NOTE: Removing old comments won't work unless Pipeline Github Plugin >= v2.0
     pipfileComment.removeAll()

--- a/vars/runPipenvInstall.groovy
+++ b/vars/runPipenvInstall.groovy
@@ -12,7 +12,7 @@ def call(parameters = [:]) {
     def installError = "\n* '`pipenv install`' has failed."
     
     // Modified version to pipenv because of https://github.com/pypa/pipenv/issues/3560
-    sh "pip install --user --upgrade pip setuptools wheel pipenv"
+    sh "pip install --user --upgrade pip setuptools wheel pipenv==2018.10.13"
     // NOTE: Removing old comments won't work unless Pipeline Github Plugin >= v2.0
     pipfileComment.removeAll()
 


### PR DESCRIPTION
See https://github.com/pypa/pipenv/issues/3560 for details about the specific issue encountered. This is currently happening for our inventory container build and breaking smoke tests.