### PR TITLE
Getting rid of custom jenkins slaves

### DIFF
--- a/Jenkinsfile-example.groovy
+++ b/Jenkinsfile-example.groovy
@@ -24,7 +24,7 @@ node {
 
 def runStages() {
     // withNode is a helper to spin up a jnlp slave using the Kubernetes plugin, and run the body code on that slave
-    openShift.withNode(image: "docker-registry.default.svc:5000/jenkins/jenkins-slave-base-centos7-python36:latest") {
+    openShift.withNode(image: "centos/python-36-centos7") {
         // check out source again to get it in this node's workspace
         scmVars = checkout scm
 

--- a/vars/openShift.groovy
+++ b/vars/openShift.groovy
@@ -5,7 +5,7 @@ def withNode(Map parameters = [:], Closure body) {
     image = parameters.get('image', pipelineVars.iqeCoreImage)
     cloud = parameters.get('cloud', pipelineVars.defaultCloud)
     jenkinsSlaveImage = parameters.get(
-        'namespace',
+        'jenkinsSlaveImage',
         cloud.equals(pipelineVars.defaultUICloud) ? pipelineVars.centralCIjenkinsSlaveImage : pipelineVars.jenkinsSlaveImage
     )
     namespace = parameters.get(

--- a/vars/openShift.groovy
+++ b/vars/openShift.groovy
@@ -16,6 +16,7 @@ def withNode(Map parameters = [:], Closure body) {
     limitCpu = parameters.get('resourceLimitCpu', "500m")
     requestMemory = parameters.get('resourceRequestMemory', "256Mi")
     limitMemory = parameters.get('resourceLimitMemory', "650Mi")
+    buildingContainer = parameters.get('buildingContainer', "builder")
     yaml = parameters.get('yaml')
 
     label = "test-${UUID.randomUUID().toString()}"
@@ -69,7 +70,7 @@ def withNode(Map parameters = [:], Closure body) {
 
     podTemplate(podParameters) {
         node(label) {
-            container('builder') {
+            container(buildingContainer) {
                 body()
             }
         }

--- a/vars/openShift.groovy
+++ b/vars/openShift.groovy
@@ -18,6 +18,7 @@ def withNode(Map parameters = [:], Closure body) {
     limitMemory = parameters.get('resourceLimitMemory', "1Gi")
     buildingContainer = parameters.get('buildingContainer', "builder")
     yaml = parameters.get('yaml')
+    envVars = parameters.get('envVars', [])
 
     label = "test-${UUID.randomUUID().toString()}"
 
@@ -36,12 +37,10 @@ def withNode(Map parameters = [:], Closure body) {
         podParameters['yaml'] = readTrusted(yaml)
     } else {
         if (image == pipelineVars.iqeCoreImage && cloud == pipelineVars.defaultCloud) {
-            envVars = [
+            envVars += [
                 envVar(key: 'PIP_TRUSTED_HOST', value: 'devpi.devpi.svc'),
                 envVar(key: 'PIP_INDEX_URL', value: 'http://devpi.devpi.svc:3141/root/psav'),
             ]
-        } else {
-            envVars = []
         }
         podParameters['containers'] = [
             containerTemplate(
@@ -91,16 +90,15 @@ def withUINode(Map parameters = [:], Closure body) {
     limitCpu = parameters.get('resourceLimitCpu', "750m")
     requestMemory = parameters.get('resourceRequestMemory', "256Mi")
     limitMemory = parameters.get('resourceLimitMemory', "1Gi")
+    envVars = parameters.get('envVars', [])
 
     label = "test-${UUID.randomUUID().toString()}"
 
     if (iqeCoreImage == pipelineVars.iqeCoreImage && cloud == pipelineVars.defaultCloud) {
-        envVars = [
+        envVars += [
             envVar(key: 'PIP_TRUSTED_HOST', value: 'devpi.devpi.svc'),
             envVar(key: 'PIP_INDEX_URL', value: 'http://devpi.devpi.svc:3141/root/psav'),
         ]
-    } else {
-        envVars = []
     }
 
     podParameters = [

--- a/vars/openShift.groovy
+++ b/vars/openShift.groovy
@@ -69,8 +69,8 @@ def withUINode(Map parameters = [:], Closure body) {
     iqeCoreImage = parameters.get('iqeCoreImage', pipelineVars.iqeCoreImage)
     requestCpu = parameters.get('resourceRequestCpu', "200m")
     limitCpu = parameters.get('resourceLimitCpu', "750m")
-    requestMemory = parameters.get('resourceRequestMemory', "512Mi")
-    limitMemory = parameters.get('resourceLimitMemory', "2Gi")
+    requestMemory = parameters.get('resourceRequestMemory', "256Mi")
+    limitMemory = parameters.get('resourceLimitMemory', "1Gi")
 
     label = "test-${UUID.randomUUID().toString()}"
 
@@ -87,16 +87,16 @@ def withUINode(Map parameters = [:], Closure body) {
                 args: '${computer.jnlpmac} ${computer.name}',
                 resourceRequestCpu: '100m',
                 resourceLimitCpu: '300m',
-                resourceRequestMemory: '512Mi',
-                resourceLimitMemory: '1Gi',
+                resourceRequestMemory: '256Mi',
+                resourceLimitMemory: '512Mi',
             ),
             containerTemplate(
                 name: 'selenium',
                 image: seleniumImage,
                 resourceRequestCpu: '500m',
                 resourceLimitCpu: '1',
-                resourceRequestMemory: '1Gi',
-                resourceLimitMemory: '4Gi',
+                resourceRequestMemory: '256Mi',
+                resourceLimitMemory: '3Gi',
                 envVars: [
                     envVar(key: 'HOME', value: '/home/selenium'),
                 ],

--- a/vars/openShift.groovy
+++ b/vars/openShift.groovy
@@ -97,6 +97,9 @@ def withUINode(Map parameters = [:], Closure body) {
                 resourceLimitCpu: '1',
                 resourceRequestMemory: '1Gi',
                 resourceLimitMemory: '4Gi',
+                envVars: [
+                    envVar(key: 'HOME', value: '/home/selenium'),
+                ],
             ),
             containerTemplate(
                 name: 'iqe',
@@ -111,7 +114,7 @@ def withUINode(Map parameters = [:], Closure body) {
             ),
         ],
         volumes: [
-            emptyDirVolume(mountPath: '/dev/shm', memory: false),
+            emptyDirVolume(mountPath: '/dev/shm', memory: true),
         ],
         annotations: [
            podAnnotation(key: "job-name", value: "${env.JOB_NAME}"),

--- a/vars/openShift.groovy
+++ b/vars/openShift.groovy
@@ -2,12 +2,12 @@
 
 
 def withNode(Map parameters = [:], Closure body) {
+    image = parameters.get('image', pipelineVars.iqeCoreImage)
+    cloud = parameters.get('cloud', pipelineVars.defaultCloud)
     jenkinsSlaveImage = parameters.get(
         'namespace',
         cloud.equals(pipelineVars.defaultUICloud) ? pipelineVars.centralCIjenkinsSlaveImage : pipelineVars.jenkinsSlaveImage
     )
-    image = parameters.get('image', pipelineVars.iqeCoreImage)
-    cloud = parameters.get('cloud', pipelineVars.defaultCloud)
     namespace = parameters.get(
         'namespace',
         cloud.equals(pipelineVars.defaultUICloud) ? pipelineVars.defaultUINameSpace : pipelineVars.defaultNameSpace

--- a/vars/openShift.groovy
+++ b/vars/openShift.groovy
@@ -66,12 +66,11 @@ def withUINode(Map parameters = [:], Closure body) {
     )
     slaveImage = parameters.get('slaveImage', pipelineVars.centralCIjenkinsSlaveImage)
     seleniumImage = parameters.get('seleniumImage', pipelineVars.seleniumImage)
-    iqeTestsImage = parameters.get('iqeTestsImage', pipelineVars.iqeTestsImage)
-    workingDir = parameters.get('workingDir', '/tmp')
+    iqeCoreImage = parameters.get('iqeCoreImage', pipelineVars.iqeCoreImage)
     requestCpu = parameters.get('resourceRequestCpu', "200m")
     limitCpu = parameters.get('resourceLimitCpu', "750m")
-    requestMemory = parameters.get('resourceRequestMemory', "1Gi")
-    limitMemory = parameters.get('resourceLimitMemory', "4Gi")
+    requestMemory = parameters.get('resourceRequestMemory', "512Mi")
+    limitMemory = parameters.get('resourceLimitMemory', "2Gi")
 
     label = "test-${UUID.randomUUID().toString()}"
 
@@ -85,28 +84,25 @@ def withUINode(Map parameters = [:], Closure body) {
             containerTemplate(
                 name: 'jnlp',
                 image: slaveImage,
-                alwaysPullImage: true,
                 args: '${computer.jnlpmac} ${computer.name}',
-                workingDir: workingDir,
-                resourceRequestCpu: requestCpu,
-                resourceLimitCpu: limitCpu,
-                resourceRequestMemory: requestMemory,
-                resourceLimitMemory: limitMemory,
+                resourceRequestCpu: '100m',
+                resourceLimitCpu: '300m',
+                resourceRequestMemory: '512Mi',
+                resourceLimitMemory: '1Gi',
             ),
             containerTemplate(
                 name: 'selenium',
                 image: seleniumImage,
-                alwaysPullImage: true,
-                resourceRequestCpu: requestCpu,
-                resourceLimitCpu: limitCpu,
-                resourceRequestMemory: requestMemory,
-                resourceLimitMemory: limitMemory,
+                resourceRequestCpu: '500m',
+                resourceLimitCpu: '1',
+                resourceRequestMemory: '1Gi',
+                resourceLimitMemory: '4Gi',
             ),
             containerTemplate(
                 name: 'iqe',
                 ttyEnabled: true,
                 command: 'cat',
-                image: iqeTestsImage,
+                image: iqeCoreImage,
                 alwaysPullImage: true,
                 resourceRequestCpu: requestCpu,
                 resourceLimitCpu: limitCpu,

--- a/vars/openShift.groovy
+++ b/vars/openShift.groovy
@@ -64,8 +64,9 @@ def withUINode(Map parameters = [:], Closure body) {
         'namespace',
         cloud.equals(pipelineVars.defaultUICloud) ? pipelineVars.defaultUINameSpace : pipelineVars.defaultNameSpace
     )
-    slaveImage = parameters.get('slaveImage', pipelineVars.jenkinsSlaveIqeImage)
+    slaveImage = parameters.get('slaveImage', pipelineVars.centralCIjenkinsSlaveImage)
     seleniumImage = parameters.get('seleniumImage', pipelineVars.seleniumImage)
+    iqeTestsImage = parameters.get('iqeTestsImage', pipelineVars.iqeTestsImage)
     workingDir = parameters.get('workingDir', '/tmp')
     requestCpu = parameters.get('resourceRequestCpu', "200m")
     limitCpu = parameters.get('resourceLimitCpu', "750m")
@@ -96,7 +97,17 @@ def withUINode(Map parameters = [:], Closure body) {
                 name: 'selenium',
                 image: seleniumImage,
                 alwaysPullImage: true,
-                workingDir: '',
+                resourceRequestCpu: requestCpu,
+                resourceLimitCpu: limitCpu,
+                resourceRequestMemory: requestMemory,
+                resourceLimitMemory: limitMemory,
+            ),
+            containerTemplate(
+                name: 'iqe',
+                ttyEnabled: true,
+                command: 'cat',
+                image: iqeTestsImage,
+                alwaysPullImage: true,
                 resourceRequestCpu: requestCpu,
                 resourceLimitCpu: limitCpu,
                 resourceRequestMemory: requestMemory,
@@ -114,7 +125,9 @@ def withUINode(Map parameters = [:], Closure body) {
 
     podTemplate(podParameters) {
         node(label) {
-            body()
+            container('iqe') {
+                body()
+            }
         }
     }
 }

--- a/vars/openShift.groovy
+++ b/vars/openShift.groovy
@@ -12,10 +12,10 @@ def withNode(Map parameters = [:], Closure body) {
         'namespace',
         cloud.equals(pipelineVars.defaultUICloud) ? pipelineVars.defaultUINameSpace : pipelineVars.defaultNameSpace
     )
-    requestCpu = parameters.get('resourceRequestCpu', "200m")
+    requestCpu = parameters.get('resourceRequestCpu', "100m")
     limitCpu = parameters.get('resourceLimitCpu', "500m")
-    requestMemory = parameters.get('resourceRequestMemory', "256Mi")
-    limitMemory = parameters.get('resourceLimitMemory', "650Mi")
+    requestMemory = parameters.get('resourceRequestMemory', "100Mi")
+    limitMemory = parameters.get('resourceLimitMemory', "1Gi")
     buildingContainer = parameters.get('buildingContainer', "builder")
     yaml = parameters.get('yaml')
 
@@ -52,7 +52,7 @@ def withNode(Map parameters = [:], Closure body) {
                 resourceLimitCpu: '300m',
                 resourceRequestMemory: '256Mi',
                 resourceLimitMemory: '512Mi',
-                ),
+            ),
             containerTemplate(
                 name: 'builder',
                 ttyEnabled: true,

--- a/vars/openShift.groovy
+++ b/vars/openShift.groovy
@@ -45,12 +45,12 @@ def withNode(Map parameters = [:], Closure body) {
         podParameters['containers'] = [
             containerTemplate(
                 name: 'jnlp',
-                    image: jenkinsSlaveImage,
-                    args: '${computer.jnlpmac} ${computer.name}',
-                    resourceRequestCpu: '100m',
-                    resourceLimitCpu: '300m',
-                    resourceRequestMemory: '256Mi',
-                    resourceLimitMemory: '512Mi',
+                image: jenkinsSlaveImage,
+                args: '${computer.jnlpmac} ${computer.name}',
+                resourceRequestCpu: '100m',
+                resourceLimitCpu: '300m',
+                resourceRequestMemory: '256Mi',
+                resourceLimitMemory: '512Mi',
                 ),
             containerTemplate(
                 name: 'builder',
@@ -58,7 +58,6 @@ def withNode(Map parameters = [:], Closure body) {
                 command: 'cat',
                 image: image,
                 alwaysPullImage: true,
-                args: '${computer.jnlpmac} ${computer.name}',
                 resourceRequestCpu: requestCpu,
                 resourceLimitCpu: limitCpu,
                 resourceRequestMemory: requestMemory,

--- a/vars/pipelineVars.groovy
+++ b/vars/pipelineVars.groovy
@@ -34,7 +34,7 @@ class pipelineVars implements Serializable {
     String centralCIjenkinsSlaveImage = 'docker-registry.engineering.redhat.com/centralci/jnlp-slave-base:1.5'
     String iqeCoreImage = 'quay.io/cloudservices/iqe-core'
     String iqeTestsImage = 'quay.io/cloudservices/iqe-tests'
-    String seleniumImage = 'quay.io/redhatqe/selenium:openshift'
+    String seleniumImage = 'quay.io/redhatqe/selenium-standalone'
 
     String defaultCloud = 'openshift'
     String defaultUICloud = 'upshift'

--- a/vars/pipelineVars.groovy
+++ b/vars/pipelineVars.groovy
@@ -32,6 +32,8 @@ class pipelineVars implements Serializable {
     String devCluster = "api.insights-dev.openshift.com"
 
     String jenkinsSlaveIqeImage = 'jenkins-slave-iqe:latest'
+    String centralCIjenkinsSlaveImage = 'docker-registry.engineering.redhat.com/centralci/jnlp-slave-base:1.5'
+    String iqeTestsImage = 'docker-registry.upshift.redhat.com/insights-qe/iqe-tests'
     String seleniumImage = 'selenium-fc29:latest'
 
     String defaultCloud = 'openshift'

--- a/vars/pipelineVars.groovy
+++ b/vars/pipelineVars.groovy
@@ -34,7 +34,7 @@ class pipelineVars implements Serializable {
     String centralCIjenkinsSlaveImage = 'docker-registry.engineering.redhat.com/centralci/jnlp-slave-base:1.5'
     String iqeCoreImage = 'quay.io/cloudservices/iqe-core'
     String iqeTestsImage = 'quay.io/cloudservices/iqe-tests'
-    String seleniumImage = 'selenium-fc29:latest'
+    String seleniumImage = 'quay.io/redhatqe/selenium:openshift'
 
     String defaultCloud = 'openshift'
     String defaultUICloud = 'upshift'

--- a/vars/pipelineVars.groovy
+++ b/vars/pipelineVars.groovy
@@ -13,7 +13,6 @@ class pipelineVars implements Serializable {
 
     String jenkinsSvcAccount = "jenkins"
     String defaultNameSpace = "jenkins"
-    String defaultNodeImage = "docker-registry.default.svc:5000/jenkins/jenkins-slave-base-centos7-python36:latest"
 
     String gitSshCreds = "insightsdroid-ssh-git"
 
@@ -31,6 +30,7 @@ class pipelineVars implements Serializable {
     String prodCluster = "api.insights.openshift.com"
     String devCluster = "api.insights-dev.openshift.com"
 
+    String jenkinsSlaveImage = 'openshift/jenkins-slave-base-centos7:v3.11'
     String centralCIjenkinsSlaveImage = 'docker-registry.engineering.redhat.com/centralci/jnlp-slave-base:1.5'
     String iqeCoreImage = 'quay.io/cloudservices/iqe-core'
     String iqeTestsImage = 'quay.io/cloudservices/iqe-tests'

--- a/vars/pipelineVars.groovy
+++ b/vars/pipelineVars.groovy
@@ -31,9 +31,9 @@ class pipelineVars implements Serializable {
     String prodCluster = "api.insights.openshift.com"
     String devCluster = "api.insights-dev.openshift.com"
 
-    String jenkinsSlaveIqeImage = 'jenkins-slave-iqe:latest'
     String centralCIjenkinsSlaveImage = 'docker-registry.engineering.redhat.com/centralci/jnlp-slave-base:1.5'
-    String iqeTestsImage = 'docker-registry.upshift.redhat.com/insights-qe/iqe-tests'
+    String iqeCoreImage = 'quay.io/cloudservices/iqe-core'
+    String iqeTestsImage = 'quay.io/cloudservices/iqe-tests'
     String seleniumImage = 'selenium-fc29:latest'
 
     String defaultCloud = 'openshift'

--- a/vars/pipelineVars.groovy
+++ b/vars/pipelineVars.groovy
@@ -30,7 +30,7 @@ class pipelineVars implements Serializable {
     String prodCluster = "api.insights.openshift.com"
     String devCluster = "api.insights-dev.openshift.com"
 
-    String jenkinsSlaveImage = 'openshift/jenkins-slave-base-centos7:v3.11'
+    String jenkinsSlaveImage = 'registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11'
     String centralCIjenkinsSlaveImage = 'docker-registry.engineering.redhat.com/centralci/jnlp-slave-base:1.5'
     String iqeCoreImage = 'quay.io/cloudservices/iqe-core'
     String iqeTestsImage = 'quay.io/cloudservices/iqe-tests'

--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -156,7 +156,6 @@ private def runPipeline(
         }
 
         sh """
-            export ENV_FOR_DYNACONF=smoke
             export DYNACONF_OCPROJECT=${project}
             export IQE_TESTS_LOCAL_CONF_PATH="$WORKSPACE"
 
@@ -194,7 +193,8 @@ private def allocateResourcesAndRun(
     lock(label: pipelineVars.smokeTestResourceLabel, quantity: 1, variable: "PROJECT") {
         echo "Using project: ${env.PROJECT}"
 
-        openShift.withNode(image: pipelineVars.iqeCoreImage, namespace: env.PROJECT) {
+        envVars = [envVar(key: 'ENV_FOR_DYNACONF', value: 'smoke')]
+        openShift.withNode(image: pipelineVars.iqeCoreImage, namespace: env.PROJECT, envVars: envVars) {
             runPipeline(refSpec, env.PROJECT, ocDeployerBuilderPath, ocDeployerComponentPath, 
                         ocDeployerServiceSets, pytestMarker, iqePlugins, extraEnvVars, configFileCredentialsId)
         }

--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -122,14 +122,15 @@ private def runPipeline(
         checkOutRepo(targetDir: pipelineVars.e2eDeployDir, repoUrl: pipelineVars.e2eDeployRepo, credentialsId: "InsightsDroidGitHubHTTP")
     }
 
+
+    stage("Wipe test environment") {
+        sh "ocdeployer wipe -l e2esmoke=true --no-confirm ${project}"
+    }
+
     stage("Install plugins") {
         for (String plugin : iqePlugins) {
             sh "pip install ${plugin}"
         }
-    }
-
-    stage("Wipe test environment") {
-        sh "ocdeployer wipe -l e2esmoke=true --no-confirm ${project}"
     }
 
     try {

--- a/vars/runSmokeTest.groovy
+++ b/vars/runSmokeTest.groovy
@@ -204,7 +204,7 @@ private def allocateResourcesAndRun(
     lock(label: pipelineVars.smokeTestResourceLabel, quantity: 1, variable: "PROJECT") {
         echo "Using project: ${env.PROJECT}"
 
-        openShift.withNode(image: 'docker-registry.default.svc:5000/jenkins/jenkins-slave-iqe:latest', namespace: env.PROJECT) {
+        openShift.withNode(namespace: env.PROJECT) {
             runPipeline(refSpec, env.PROJECT, ocDeployerBuilderPath, ocDeployerComponentPath, 
                         ocDeployerServiceSets, pytestMarker, iqePlugins, extraEnvVars, configFileCredentialsId)
         }


### PR DESCRIPTION
The intention of these PRs to reduce amount of custom jnlp images.  `quay.io/cloudservices/iqe-core` always contains the latest version of iqe-integration-test package. This image can be used not only in CI but also locally.