### PR TITLE
Allow priorBuildsCancelled to be run more than once

### DIFF
--- a/vars/cancelPriorBuilds.groovy
+++ b/vars/cancelPriorBuilds.groovy
@@ -1,6 +1,20 @@
+import groovy.transform.Field
+
+@Field
+def priorBuildsCancelled = false
+
 def call() {
-    milestone()
-    def buildNumber = env.BUILD_NUMBER as int
-    if (buildNumber > 1) milestone(buildNumber - 1)
-    milestone(buildNumber)
+
+    if (! priorBuildsCancelled) {
+
+        def buildNumber = env.BUILD_NUMBER as int
+
+        if (buildNumber > 1) {
+            milestone(buildNumber - 1)
+        }
+
+        milestone(buildNumber)
+
+        priorBuildsCancelled = true
+    }
 }


### PR DESCRIPTION
It allows the cancelPriorBuilds to be run more than once by keeping a flag as a record of whether it was called or not. 

@bsquizz  please review.