### PR TITLE
openShift.withNode contains two containers. 

### DIFF
--- a/vars/pipelineVars.groovy
+++ b/vars/pipelineVars.groovy
@@ -13,7 +13,6 @@ class pipelineVars implements Serializable {
 
     String jenkinsSvcAccount = "jenkins"
     String defaultNameSpace = "jenkins"
-    String defaultNodeImage = "docker-registry.default.svc:5000/jenkins/jenkins-slave-base-centos7-python36:latest"
 
     String gitSshCreds = "insightsdroid-ssh-git"
 
@@ -30,6 +29,10 @@ class pipelineVars implements Serializable {
 
     String prodCluster = "api.insights.openshift.com"
     String devCluster = "api.insights-dev.openshift.com"
+
+    String jenkinsSlaveImage = 'openshift/jenkins-slave-base-centos7:v3.11'
+    String centralCIjenkinsSlaveImage = 'docker-registry.engineering.redhat.com/centralci/jnlp-slave-base:1.5'
+    String iqeCoreImage = 'quay.io/cloudservices/iqe-core'
 
     String jenkinsSlaveIqeImage = 'jenkins-slave-iqe:latest'
     String seleniumImage = 'selenium-fc29:latest'


### PR DESCRIPTION
Follow up of #40.  The intention of these PRs to reduce amount of custom jnlp images. `quay.io/cloudservices/iqe-core` always contains the latest version of `iqe-integration-test` package. This image can be used not only in CI but also locally.