### PR TITLE
Fix bug when calling cancelPriorBuilds twice

### DIFF
--- a/vars/cancelPriorBuilds.groovy
+++ b/vars/cancelPriorBuilds.groovy
@@ -1,11 +1,7 @@
-import groovy.transform.Field
-
-@Field
-def priorBuildsCancelled = false
 
 def call() {
 
-    if (! priorBuildsCancelled) {
+    if (! env.priorBuildsCancelled) {
 
         def buildNumber = env.BUILD_NUMBER as int
 
@@ -15,6 +11,6 @@ def call() {
 
         milestone(buildNumber)
 
-        priorBuildsCancelled = true
+        env.priorBuildsCancelled = true
     }
 }


### PR DESCRIPTION
- Changes @Field implementation for `env` variable so the status of
whether the cancelPriorBuilds function has already been called no matter
the context where it's referenced from.