### PR TITLE
Add null check for extraContainers

### DIFF
--- a/vars/openShiftUtils.groovy
+++ b/vars/openShiftUtils.groovy
@@ -86,7 +86,9 @@ def withNode(Map parameters = [:], Closure body) {
         ]
     }
 
-    podParameters['containers'].addAll(extraContainers)
+    if (extraContainers) {
+        podParameters['containers'].addAll(extraContainers)
+    }
 
     podTemplate(podParameters) {
         node(label) {


### PR DESCRIPTION
@bsquizz could you please take a look? We are getting failed pipelines like this: https://jenkins-jenkins.5a9f.insights-dev.openshiftapps.com/blue/organizations/jenkins/compliance-backend/detail/PR-278/3/pipeline

> Cannot invoke method addAll() on null object

Signed-off-by: Andrew Kofink <akofink@redhat.com>