### PR TITLE
Add some helper functions related to Quay

### DIFF
--- a/vars/deployUtils.groovy
+++ b/vars/deployUtils.groovy
@@ -422,9 +422,9 @@ def skopeoCopy(parameters = [:]) {
     def srcUri = parameters['srcUri']
     def dstUri = parameters['dstUri']
     def srcUser = parameters['srcUser']
-    def srcTokenId = parameters['srcToken']
+    def srcTokenId = parameters['srcTokenId']
     def dstUser = parameters['dstUser']
-    def dstTokenId = parameters['dstToken']
+    def dstTokenId = parameters['dstTokenId']
 
     withCredentials(
         [

--- a/vars/deployUtils.groovy
+++ b/vars/deployUtils.groovy
@@ -473,3 +473,8 @@ def promoteImages(parameters = [:]) {
         }
     }
 }
+
+
+def mirrorImage(parameters = [:]) {
+    def srcImageTag = parameters['srcImageTag']
+}

--- a/vars/execQuayCopy.groovy
+++ b/vars/execQuayCopy.groovy
@@ -27,8 +27,8 @@ def call(parameters = [:]) {
                 def tags = [isTag, commitIsTag]
                 tags.each { tag ->
                     deployUtils.skopeoCopy(
-                        srcUri: srcBaseUri + tag
-                        dstUri: dstBaseUri + tag
+                        srcUri: srcBaseUri + tag,
+                        dstUri: dstBaseUri + tag,
                         srcUser: "na",
                         srcTokenId: srcTokenId,
                         dstUser: dstUser,

--- a/vars/execQuayCopy.groovy
+++ b/vars/execQuayCopy.groovy
@@ -1,0 +1,33 @@
+def call(parameters = [:]) {
+    def isTags = parameters['isTags']  // required param
+    def jnlpImage = parameters.get('jnlpImage', "jenkins-deploy-jnlp:latest")
+    def srcNamespace = parameters.get('srcNamespace', "buildfactory")
+    def srcBaseUri = parameters.get(
+        "srcBaseUri",
+        "docker://registry.insights-dev.openshift.com/" + srcNamespace
+    )
+    def dstBaseUri = parameters.get("dstBaseUri", "docker://quay.io/cloudservices/")
+    def srcTokenId = parameters.get("srcTokenId", "buildfactoryDeployerToken")
+    def dstUser = parameters.get("dstUser", "cloudservices+push")
+    def dstTokenId = parameters.get("dstTokenId", "quay-cloudservices-push-token")
+
+
+    stage("Start jnlp container") {
+        openShiftUtils.withJnlpNode(image: jnlpImage) {
+            stage("Copy images") {
+                isTags.each { isTag ->
+                    sh "oc describe istag ${isTag}"
+
+                    deployUtils.skopeoCopy(
+                        srcUri: srcBaseUri + isTag
+                        dstUri: dstBaseUri + isTag
+                        srcUser: "na",
+                        srcTokenId: srcTokenId,
+                        dstUser: dstUser,
+                        dstTokenId: dstTokenId
+                    )
+                }
+            }
+        }
+    }
+}

--- a/vars/execQuayCopy.groovy
+++ b/vars/execQuayCopy.groovy
@@ -5,7 +5,7 @@ def call(parameters = [:]) {
     def srcNamespace = parameters.get('srcNamespace', "buildfactory")
     def srcBaseUri = parameters.get(
         "srcBaseUri",
-        "docker://registry.insights-dev.openshift.com/" + srcNamespace
+        "docker://registry.insights-dev.openshift.com/" + srcNamespace + "/"
     )
     def dstBaseUri = parameters.get("dstBaseUri", "docker://quay.io/cloudservices/")
     def srcTokenId = parameters.get("srcTokenId", "buildfactoryDeployerToken")

--- a/vars/execQuayCopy.groovy
+++ b/vars/execQuayCopy.groovy
@@ -19,8 +19,11 @@ def call(parameters = [:]) {
             stage("Copy images") {
                 def isTag = imageName + ":" + imageTag
                 def commitId = sh(
-                    "oc describe istag ${isTag} -n ${srcNamespace}" +
-                    "| grep ${commitLabel} | cut -f2 -d'='"
+                    script: (
+                        "oc describe istag ${isTag} -n ${srcNamespace}" +
+                        "| grep ${commitLabel} | cut -f2 -d'='"
+                    )
+                    returnStdout: true
                 )
                 def commitIsTag = imageName + ":" + commitId
                 sh("oc tag ${isTag} ${commitIsTag} -n ${srcNamespace}")

--- a/vars/execQuayCopy.groovy
+++ b/vars/execQuayCopy.groovy
@@ -1,6 +1,7 @@
 def call(parameters = [:]) {
     def imageName = parameters['imageName']  // required param
-    def imageTag = parameters['imageTag']
+    def imageTag = parameters['imageTag']  // required param
+    def dstImageName = parameters.get('dstImageName', imageName)
     def jnlpImage = parameters.get('jnlpImage', "jenkins-deploy-jnlp:latest")
     def srcNamespace = parameters.get('srcNamespace', "buildfactory")
     def srcBaseUri = parameters.get(
@@ -28,7 +29,7 @@ def call(parameters = [:]) {
                 def commitIsTag = imageName + ":" + commitId
                 sh("oc tag ${isTag} ${commitIsTag} -n ${srcNamespace}")
 
-                def tags = [isTag, commitIsTag]
+                def tags = [dstImageName + ":" + imageTag, dstImageName + ":" + commitId]
                 tags.each { tag ->
                     deployUtils.skopeoCopy(
                         srcUri: srcBaseUri + tag,

--- a/vars/execQuayCopy.groovy
+++ b/vars/execQuayCopy.groovy
@@ -19,7 +19,8 @@ def call(parameters = [:]) {
             stage("Copy images") {
                 def isTag = imageName + ":" + imageTag
                 def commitId = sh(
-                    "oc describe istag ${isTag} | grep ${commitLabel} | cut -f2 -d'='"
+                    "oc describe istag ${isTag} -n ${srcNamespace}" +
+                    "| grep ${commitLabel} | cut -f2 -d'='"
                 )
                 def commitIsTag = imageName + ":" + commitId
                 sh("oc tag ${isTag} ${commitIsTag}")

--- a/vars/execQuayCopy.groovy
+++ b/vars/execQuayCopy.groovy
@@ -23,7 +23,7 @@ def call(parameters = [:]) {
                     "| grep ${commitLabel} | cut -f2 -d'='"
                 )
                 def commitIsTag = imageName + ":" + commitId
-                sh("oc tag ${isTag} ${commitIsTag}")
+                sh("oc tag ${isTag} ${commitIsTag} -n ${srcNamespace}")
 
                 def tags = [isTag, commitIsTag]
                 tags.each { tag ->

--- a/vars/openShiftUtils.groovy
+++ b/vars/openShiftUtils.groovy
@@ -241,7 +241,7 @@ def withJnlpNode(Map parameters = [:], Closure body) {
 
     podTemplate(podParameters) {
         node(label) {
-            container(jnlp) {
+            container('jnlp') {
                 body()
             }
         }

--- a/vars/openShiftUtils.groovy
+++ b/vars/openShiftUtils.groovy
@@ -193,8 +193,8 @@ def withJnlpNode(Map parameters = [:], Closure body) {
     /*
     Spins up a pod with a single jnlp container
     */
-    def image = parameters.get('image', getDefaultSlaveImage(cloud))
     def cloud = parameters.get('cloud', pipelineVars.defaultCloud)
+    def image = parameters.get('image', getDefaultSlaveImage(cloud))
     def namespace = parameters.get('namespace', getDefaultSlaveNamespace(cloud))
     def jnlpRequestCpu = parameters.get('jnlpRequestCpu', "100m")
     def jnlpLimitCpu = parameters.get('jnlpLimitCpu', "300m")

--- a/vars/openShiftUtils.groovy
+++ b/vars/openShiftUtils.groovy
@@ -26,6 +26,9 @@ private def setDevPiEnvVars(String image, String cloud, Collection envVars) {
 
 
 def withNode(Map parameters = [:], Closure body) {
+    /*
+    Spins up a pod with 2 containers: jnlp, and specified 'image'
+    */
     def image = parameters.get('image', pipelineVars.iqeCoreImage)
     def cloud = parameters.get('cloud', pipelineVars.defaultCloud)
     def jenkinsSlaveImage = parameters.get('jenkinsSlaveImage', getDefaultSlaveImage(cloud))
@@ -43,7 +46,7 @@ def withNode(Map parameters = [:], Closure body) {
     def envVars = parameters.get('envVars', [])
     def extraContainers = parameters.get('extraContainers', [])
 
-    def label = "test-${UUID.randomUUID().toString()}"
+    def label = "node-${UUID.randomUUID().toString()}"
 
     podParameters = [
         label: label,
@@ -101,6 +104,9 @@ def withNode(Map parameters = [:], Closure body) {
 
 
 def withUINode(Map parameters = [:], Closure body) {
+    /* 
+    Spins up a pod with 3 containers: jnlp, selenium, and specified 'image'
+    */
     def cloud = parameters.get('cloud', pipelineVars.upshiftCloud)
     def namespace = parameters.get('namespace', getDefaultSlaveNamespace(cloud))
     def slaveImage = parameters.get('slaveImage', getDefaultSlaveImage(cloud))
@@ -117,7 +123,7 @@ def withUINode(Map parameters = [:], Closure body) {
     def envVars = parameters.get('envVars', [])
     def extraContainers = parameters.get('extraContainers', [])
 
-    def label = "test-${UUID.randomUUID().toString()}"
+    def label = "node-${UUID.randomUUID().toString()}"
 
     setDevPiEnvVars(image, cloud, envVars)
 
@@ -176,6 +182,66 @@ def withUINode(Map parameters = [:], Closure body) {
     podTemplate(podParameters) {
         node(label) {
             container('iqe') {
+                body()
+            }
+        }
+    }
+}
+
+
+def withJnlpNode(Map parameters = [:], Closure body) {
+    /*
+    Spins up a pod with a single jnlp container
+    */
+    def image = parameters.get('image', getDefaultSlaveImage(cloud))
+    def cloud = parameters.get('cloud', pipelineVars.defaultCloud)
+    def namespace = parameters.get('namespace', getDefaultSlaveNamespace(cloud))
+    def jnlpRequestCpu = parameters.get('jnlpRequestCpu', "100m")
+    def jnlpLimitCpu = parameters.get('jnlpLimitCpu', "300m")
+    def jnlpRequestMemory = parameters.get('jnlpRequestMemory', "100Mi")
+    def jnlpLimitMemory = parameters.get('jnlpLimitMemory', "512Mi")
+    def yaml = parameters.get('yaml')
+    def envVars = parameters.get('envVars', [])
+    def extraContainers = parameters.get('extraContainers', [])
+
+    def label = "node-${UUID.randomUUID().toString()}"
+
+    podParameters = [
+        label: label,
+        slaveConnectTimeout: 120,
+        serviceAccount: pipelineVars.jenkinsSvcAccount,
+        cloud: cloud,
+        namespace: namespace,
+        annotations: [
+            podAnnotation(key: "job-name", value: "${env.JOB_NAME}"),
+            podAnnotation(key: "run-display-url", value: "${env.RUN_DISPLAY_URL}"),
+        ]
+    ]
+    if (yaml) {
+        podParameters['yaml'] = readTrusted(yaml)
+    } else {
+        setDevPiEnvVars(image, cloud, envVars)
+
+        podParameters['containers'] = [
+            containerTemplate(
+                name: 'jnlp',
+                image: image,
+                args: '${computer.jnlpmac} ${computer.name}',
+                resourceRequestCpu: jnlpRequestCpu,
+                resourceLimitCpu: jnlpLimitCpu,
+                resourceRequestMemory: jnlpRequestMemory,
+                resourceLimitMemory: jnlpLimitMemory,
+            )
+        ]
+    }
+
+    if (extraContainers) {
+        podParameters['containers'].addAll(extraContainers)
+    }
+
+    podTemplate(podParameters) {
+        node(label) {
+            container(jnlp) {
                 body()
             }
         }


### PR DESCRIPTION
1) Add withJnlpNode so we can spin up a pod w/ a single container -- a custom jnlp slave (instead of spinning up a pod w/ a jnlp container and some other custom container)

2) Add skopeoCopy -- we had much of this code in 'promoteImages' but it wasn't generalized enough for other skopeo uses so some of it was pulled out into a separate function

3) Add execQuayCopy -- this defines the logic that pipeline build configs will use to copy an image to quay.