### PR TITLE
Updated central CI jenkins slave image

### DIFF
--- a/vars/pipelineVars.groovy
+++ b/vars/pipelineVars.groovy
@@ -22,7 +22,7 @@ class pipelineVars implements Serializable {
         'registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11'
     )
     String centralCIjenkinsSlaveImage = (
-        'docker-registry.engineering.redhat.com/centralci/jnlp-slave-base:1.5'
+        'docker-registry.upshift.redhat.com/ccit/jenkins-slave-centos7:2.150.2'
     )
     String iqeCoreImage = 'quay.io/cloudservices/iqe-core'
     String iqeTestsImage = 'quay.io/cloudservices/iqe-tests'


### PR DESCRIPTION
The old registry was decommissioned, central CI uses another registry.