### PR TITLE
New custom jenkins slave image

### DIFF
--- a/vars/pipelineVars.groovy
+++ b/vars/pipelineVars.groovy
@@ -22,7 +22,7 @@ class pipelineVars implements Serializable {
         'registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11'
     )
     String centralCIjenkinsSlaveImage = (
-        'docker-registry.upshift.redhat.com/ccit/jenkins-slave-centos7:2.150.2'
+        'docker-registry.upshift.redhat.com/insights-qe/jenkins-slave-base:latest'
     )
     String iqeCoreImage = 'quay.io/cloudservices/iqe-core'
     String iqeTestsImage = 'quay.io/cloudservices/iqe-tests'


### PR DESCRIPTION
That one should work. It's based on https://hub.docker.com/layers/openshift/jenkins-slave-base-centos7/v3.11/images/sha256-d14f95a013e82c66122b386c548663a2d3fe69fff8e2c63fa598b8d3a3d5587a with adding Red Hat internal certificates. I tested it in this code:

```groovy
@Library("github.com/RedHatInsights/insights-pipeline-lib@v3") _

openShiftUtils.withNode(
    image: "docker-registry.upshift.redhat.com/ccx-dev/ccx-e2e:latest",
    jenkinsSlaveImage: "docker-registry.upshift.redhat.com/insights-qe/jenkins-slave-base:latest",
    cloud: "jenkins-csb-ccx",
    namespace: "jenkins-csb-ccx"
) {
    ...
}
```