### PR TITLE
Added workaround when GIT_COMMIT points to a no repo commit SHA.

### DIFF
--- a/vars/gitUtils.groovy
+++ b/vars/gitUtils.groovy
@@ -186,3 +186,22 @@ def stageWithContext(String name, Boolean shortenURL = true, Closure body) {
         }
     }
 }
+
+def getBaseCommit() {
+    /**
+    * GIT_COMMIT can point to a no repo commit SHA. A workaround is taken from
+    * https://issues.jenkins-ci.org/browse/JENKINS-56341
+    */
+    def baseCommit = ''
+    def latestCommit = sh(label: 'Get previous commit', script: "git rev-parse HEAD", returnStdout: true)?.trim()
+    def previousCommit = sh(label: 'Get previous commit', script: "git rev-parse HEAD^", returnStdout: true)?.trim()
+    if (env?.CHANGE_ID == null) {
+        baseCommit = env.GIT_COMMIT
+    } else if("${env.GIT_COMMIT}".equals("${latestCommit}")) {
+        baseCommit = env.GIT_COMMIT
+    } else {
+        baseCommit = previousCommit
+    }
+    env.GIT_BASE_COMMIT = baseCommit
+    return baseCommit
+}


### PR DESCRIPTION
I faced an issue when I needed to submit a coverage report to Codecov and it requires a PR head commit. During `checkout scm` you can see what Jenkins does with commits:
```text
Merging remotes/origin/master commit 0540b06ffe74242985377cb71d7d307ab729b960 into PR head commit 3f05f9476621e555ac9754444ce6eb4377dacba0
...
[Pipeline] echo

        env.CHANGE_ID:                  812
        env.BRANCH_NAME:                PR-812
        GIT_COMMIT:                     9ec2c0caa13bf9687e76cc3f1100572de1985b2a
        GIT_PREVIOUS_SUCCESSFUL_COMMIT: 93c93e7a3fdd1e70bac4a280517242b7f2569d67
        GIT_URL:                        https://github.com/RedHatInsights/insights-results-aggregator.git
        
[Pipeline] }
...
```
The "real" commit is PR head commit `3f05f9476621e555ac9754444ce6eb4377dacba0` but Jenkins merges it wth the master commit and produces commit which doesnt exist in the repo `9ec2c0caa13bf9687e76cc3f1100572de1985b2a`.

 The problem described in https://issues.jenkins-ci.org/browse/JENKINS-56341.