### PR TITLE
Enforce settings file name for IQE tests

### DIFF
--- a/vars/execIQETests.groovy
+++ b/vars/execIQETests.groovy
@@ -236,7 +236,7 @@ def prepareStages(Map appConfigs, String cloud) {
                         [file(credentialsId: settingsFileCredentialsId, variable: "YAML_FILE")]
                     ) {
                         sh "mkdir -p \$IQE_TESTS_LOCAL_CONF_PATH"
-                        sh "cp \$YAML_FILE \$IQE_TESTS_LOCAL_CONF_PATH"
+                        sh "cp \$YAML_FILE \$IQE_TESTS_LOCAL_CONF_PATH/settings.local.yaml"
                     }
                 }
                 stage("Install red-hat-internal-envs plugin") {


### PR DESCRIPTION
Enforce the name of the IQE settings file used in the pipeline to `settings.local.yaml` to avoid checking out a file with a name that doesn't follow the expected naming convention.