### PR TITLE
Remove DEBUG log level

### DIFF
--- a/vars/iqeUtils.groovy
+++ b/vars/iqeUtils.groovy
@@ -186,7 +186,7 @@ def runIQE(String plugin, Map appOptions) {
                 ${filterArgs} \
                 -n ${appOptions['parallelWorkerCount']} \
                 ${ibutsuArgs} \
-                --log-file=iqe-${plugin}-parallel.log --log-file-level=DEBUG 2>&1 \
+                --log-file=iqe-${plugin}-parallel.log
                 """.stripIndent()
             ),
             returnStatus: true
@@ -214,7 +214,7 @@ def runIQE(String plugin, Map appOptions) {
                 ${markerArgs} \
                 ${filterArgs} \
                 ${ibutsuArgs} \
-                --log-file=iqe-${plugin}-sequential.log --log-file-level=DEBUG 2>&1 \
+                --log-file=iqe-${plugin}-sequential.log
                 """.stripIndent()
             ),
             returnStatus: true


### PR DESCRIPTION
The DEBUG log-level caused large `iqe.log` files (anywhere from 1-40 MB) to be uploaded to Ibutsu. This in turn caused problems with disk usage in our DB.