### PR TITLE
Don't use latest tag for selenium image

### DIFF
--- a/vars/pipelineVars.groovy
+++ b/vars/pipelineVars.groovy
@@ -35,7 +35,7 @@ class pipelineVars implements Serializable {
     )
     String iqeCoreImage = 'quay.io/cloudservices/iqe-core:latest'
     String iqeTestsImage = 'quay.io/cloudservices/iqe-tests:latest'
-    String seleniumImage = 'quay.io/redhatqe/selenium-standalone:latest'
+    String seleniumImage = 'quay.io/redhatqe/selenium-standalone:ff_78.0.2esr_gecko_v0.26.0_chrome_84.0.4147.89'
 
     String defaultCloud = 'openshift'
     String defaultNamespace = 'jenkins'


### PR DESCRIPTION
We should explicitly specify versions of browsers and gecko driver in selenium image.