### PR TITLE
Add 'image' as a parameter for execIQETests

### DIFF
--- a/vars/execIQETests.groovy
+++ b/vars/execIQETests.groovy
@@ -24,6 +24,7 @@ def call(args = [:]) {
     def options = args.get('options', [:])
     def defaultMarker = args.get('defaultMarker')
     def defaultFilter = args.get('defaultFilter')
+    def defaultImage = args.get('defaultImage')
     def extraJobProperties = args.get('extraJobProperties', [])
     def lockName = args.get('lockName')
 
@@ -74,6 +75,15 @@ def call(args = [:]) {
         ]
     )
 
+    // Add text field for test image
+    p.add(
+        [
+            $class: 'StringParameterDefinition',
+            name: "image", defaultValue: defaultImage ? defaultImage : "",
+            description: "Enter the name of the core image, leave blank for iqe-core"
+        ]
+    )
+
     def jobProperties = [parameters(p)]
     jobProperties.addAll(extraJobProperties)
 
@@ -95,6 +105,7 @@ def call(args = [:]) {
     options['envName'] = params.env
     options['marker'] = params.marker
     options['filter'] = params.filter
+    options['image'] = params.image
     options['ibutsu'] = options.get('ibutsu', true)
     options['cloud'] = options.get('cloud', pipelineVars.upshiftCloud)
     options['timeout'] = options.get('timeout', 150)

--- a/vars/iqeUtils.groovy
+++ b/vars/iqeUtils.groovy
@@ -48,7 +48,8 @@ private def parseOptions(Map options) {
     def envName = options['envName']
 
     // the container image that the tests will run with in OpenShift
-    options['image'] = options.get('image', pipelineVars.iqeCoreImage)
+    // we use a ternary here to deal with the empty string
+    options['image'] = options.get('image') ? options.get("image") : pipelineVars.iqeCoreImage
 
     // the namespace that the test pods run in
     options['namespace'] = options.get('namespace')


### PR DESCRIPTION
This parameter will allow us to specify an image other than `quay.io/cloudservices/iqe-core:latest` when running `execIQETests`.

This will be useful for e.g. building an image of `iqe-core` against master or some in review branch and kicking off a test run against it.

First part of the work for https://issues.redhat.com/browse/IQE-735