### PR TITLE
collect browser logs

### DIFF
--- a/vars/iqeUtils.groovy
+++ b/vars/iqeUtils.groovy
@@ -207,6 +207,8 @@ def runIQE(String plugin, Map appOptions) {
                 -n ${appOptions['parallelWorkerCount']} \
                 ${ibutsuArgs} \
                 --log-file=iqe-${plugin}-parallel.log 2>&1 \
+                --browserlog \
+                --netlog \
                 """.stripIndent()
             ),
             returnStatus: true
@@ -236,6 +238,8 @@ def runIQE(String plugin, Map appOptions) {
                 ${extraArgs} \
                 ${ibutsuArgs} \
                 --log-file=iqe-${plugin}-sequential.log 2>&1 \
+                --browserlog \
+                --netlog \
                 """.stripIndent()
             ),
             returnStatus: true


### PR DESCRIPTION
use `--browserlog` and `--netlog` to collect browser logs if they are available (user needs to allow logging https://github.com/RedHatInsights/iqe-jenkins/pull/250/files). If logging is not allowed it won't collect any logs.