### PR TITLE
Add error result to runIQE and execIQETests

### DIFF
--- a/vars/execIQETests.groovy
+++ b/vars/execIQETests.groovy
@@ -135,7 +135,7 @@ def call(args = [:]) {
     }
 
     if (!results) error("Found no test results")
-    def totalResults = results['success'].size() + results['failed'].size()
+    def totalResults = results['success'].size() + results['failed'].size() + results['error'].size()
     if (totalResults != appConfigs.keySet().size()) error("Did not find test results for expected number of apps")
 
     return results

--- a/vars/iqeUtils.groovy
+++ b/vars/iqeUtils.groovy
@@ -7,7 +7,7 @@
  * Example:
  *     results = pipelineUtils.runParallel(iqeUtils.prepareStages(options, appConfigs))
  *
- * 'results' will be a Map with two keys: 'success' and 'failed'. Each key contains a list of which
+ * 'results' will be a Map with three keys: 'success', 'error', and 'failed'. Each key contains a list of which
  * parallel stage failed.
  *
  * OPTIONS
@@ -172,7 +172,10 @@ def runIQE(String plugin, Map appOptions) {
      *
      * If an IQE run fails, then fail the stage. Ignore pytest failing for having 0 tests collected
      *
-     * Returns result of "SUCCESS" or "FAILURE"
+     * Returns result of "SUCCESS", "ERROR", or "FAILURE"
+     * The "FAILURE" result is only returned if there are actual test failures, cf
+     * https://docs.pytest.org/en/documentation-restructure/how-to/usage.html#possible-exit-codes
+     * for information on pytest exit codes.
      */
     def collectionStatus
     def result
@@ -203,7 +206,7 @@ def runIQE(String plugin, Map appOptions) {
     def marker = appOptions['marker']
     def extraArgs = appOptions['extraArgs']
 
-    catchError(stageResult: "FAILURE") {
+    catchError(stageResult: "ERROR") {
         // run parallel tests
         def errorMsgParallel = ""
         def errorMsgSequential = ""
@@ -229,7 +232,7 @@ def runIQE(String plugin, Map appOptions) {
             noTests = true
         }
         else if (collectionStatus > 0) {
-            result = "FAILURE"
+            result = "ERROR"
             errorMsgParallel = "Parallel test run collection failed with exit code ${status}"
         }
         // only run tests when the collection status is 0
@@ -252,9 +255,13 @@ def runIQE(String plugin, Map appOptions) {
                 ),
                 returnStatus: true
             )
-            if (status > 0) {
+            if (status == 1) {
                 result = "FAILURE"
-                errorMsgParallel = "Parallel test run failed with exit code ${status}."
+                errorMsgParallel = "Parallel test run failed with pytest exit code ${status}."
+            }
+            else {
+                result = "ERROR"
+                errorMsgParallel = "Parallel test run hit an error with pytest exit code ${status}."
             }
         }
 
@@ -283,7 +290,7 @@ def runIQE(String plugin, Map appOptions) {
             error("Tests produced no results")
         }
         else if (collectionStatus > 0) {
-            result = "FAILURE"
+            result = "ERROR"
             errorMsgSequential = "Sequential test run collection failed with exit code ${status}"
         }
         // only run tests when the collection status is 0
@@ -305,9 +312,13 @@ def runIQE(String plugin, Map appOptions) {
                 ),
                 returnStatus: true
             )
-            if (status > 0) {
+            if (status == 1) {
                 result = "FAILURE"
-                errorMsgSequential = "Sequential test run failed with exit code ${status}."
+                errorMsgSequential = "Sequential test run failed with pytest exit code ${status}."
+            }
+            else {
+                result = "ERROR"
+                errorMsgSequential = "Sequential test run hit an error with pytest exit code ${status}."
             }
         }
         // if there were no failures recorded, it's a success
@@ -488,14 +499,16 @@ private def createTestStages(String appName, Map appConfig) {
 
     stage("Results") {
         def pluginsFailed = pluginResults.findAll { it.value == "FAILURE" }
+        def pluginsError = pluginResults.findAll { it.value == "ERROR" }
         def pluginsPassed = pluginResults.findAll { it.value == "SUCCESS" }
 
         // stash junit files so that other nodes can read them later
         stash name: "${appName}-stash-files", allowEmpty: true, includes: "junit-*.xml"
 
         echo "Plugins passed: ${pluginsPassed.keySet().join(",")}"
-        if (pluginsFailed) {
-            error "Plugins failed: ${pluginsFailed.keySet().join(",")}"
+        if (pluginsFailed || pluginsError) {
+            error "Plugins failed: ${pluginsFailed.keySet().join(",")}" \
+                  " Plugins error: ${pluginsError}.keySet().join(",")}"
         }
         else if (!pluginsPassed) {
             error "No plugins failed nor passed. Were the test runs aborted early?"


### PR DESCRIPTION
I noticed that sometimes plugin pipelines will have a `FAILURE` state not because a test failed but because `pytest` hit some `InternalError` in the framework. 

In my opinion, we should handle this instance as an ERROR state and not a FAILURE state, so that slack messages from `execIQETestsWithNotifier` are sent to the `errorSlackChannel` rather than the `slackChannel`

I am basing the `FAILURE` state on exit code == 1 from pytest (https://docs.pytest.org/en/documentation-restructure/how-to/usage.html#possible-exit-codes). 