### PR TITLE
Fix wrong status set

### DIFF
--- a/vars/iqeUtils.groovy
+++ b/vars/iqeUtils.groovy
@@ -206,7 +206,7 @@ def runIQE(String plugin, Map appOptions) {
     def marker = appOptions['marker']
     def extraArgs = appOptions['extraArgs']
 
-    catchError(stageResult: "ERROR") {
+    catchError(stageResult: "FAILURE") {
         // run parallel tests
         def errorMsgParallel = ""
         def errorMsgSequential = ""
@@ -255,13 +255,9 @@ def runIQE(String plugin, Map appOptions) {
                 ),
                 returnStatus: true
             )
-            if (status == 1) {
+            if (status > 0) {
                 result = "FAILURE"
                 errorMsgParallel = "Parallel test run failed with pytest exit code ${status}."
-            }
-            else {
-                result = "ERROR"
-                errorMsgParallel = "Parallel test run hit an error with pytest exit code ${status}."
             }
         }
 


### PR DESCRIPTION
`ERROR` is not a valid pipeline status value, the only accepted values are explicitly stated in the error log: 

```
java.lang.IllegalArgumentException: stageResult is invalid: ERROR. Valid options are SUCCESS, UNSTABLE, FAILURE, NOT_BUILT and ABORTED.
```

This PR sets a "failed" or "error" status back to "FAILURE" state. 
It also rolls back the evaluation logic of the `exit_code` for the `iqe tests` run from #133 

please @john-dupuy  review these changes, esp. the exit code evaluation, I might be wrong on assuming the intention of the different status code (I dropped a note in the merged PR [here](https://github.com/RedHatInsights/insights-pipeline-lib/pull/133#discussion_r608535706) as well)