### PR TITLE
Install iqe-rhc-plugin[client]

### DIFF
--- a/vars/clientUtils.groovy
+++ b/vars/clientUtils.groovy
@@ -234,6 +234,11 @@ def setupIqePlugin(Map parameters = [:]){
             // systemctl enable docker.service
             // systemctl start docker.service
     }
+    else if(plugin.contains('rhc')) {
+        sh """
+            pip install --editable .[client]
+        """
+    }
 
 
     withCredentials([file(credentialsId: jenkins_credentials, variable: 'settings')]) {


### PR DESCRIPTION
When installing iqe-rhc-plugin so that RHC client tests can be executed,
make sure to install the "client" extra, which pulls in dependencies
(currently just pystemd) that are needed only by the RHC client tests.
Without this, iqe-rhc-plugin will install, but `import pystemd` will
fail at runtime.