### PR TITLE
Remove 'advisor' from deploy jobs

### DIFF
--- a/vars/deployUtils.groovy
+++ b/vars/deployUtils.groovy
@@ -15,7 +15,6 @@ import hudson.util.Secret
 
 // Map of service set name -> Jenkins location of deploy job for that service set
 @Field def deployJobs = [
-    advisor: "/ops/deployAdvisor",
     approval: "/ops/deployApproval",
     "automation-analytics": "/ops/deployAutomationAnalytics",
     buildfactory: "/ops/deployBuildfactory",


### PR DESCRIPTION
Advisor has switched fully over to new deployment pipelines

Depends on https://github.com/RedHatInsights/e2e-deploy/pull/3446