### PR TITLE
Add functions for CCI Jenkins

### DIFF
--- a/vars/cciJenkins.groovy
+++ b/vars/cciJenkins.groovy
@@ -1,0 +1,72 @@
+/**
+ * Functions for jobs on cci-jenkins.
+ *
+ * WARNING: This module is targeted at:
+ * https://gitlab.cee.redhat.com/insights-qe/cci-jenkins-insights-config-declaration/. All other
+ * users, caveat emptor.
+ *
+ * This module provides functions for authoring focused Jenkins jobs which do the following:
+ *
+ * * Execute tests from a single IQE plugin.
+ * * Declaratively define job properties and stages.
+ * * Pass functions only the arguments they need.
+ *
+ * In constrast, execIQETests does the following:
+ *
+ * * Potentially execute tests from multiple IQE plugins.
+ * * Dynamically (i.e. at runtime) define job properties and stages.
+ * * Pass functions large maps of arguments.
+ *
+ * This module doesn't reinvent low-level logic for executing tests. Instead, it makes the
+ * lower-level logic that execIQETests executes more accessible.
+ */
+
+/**
+ * Build arguments for iqeUtils.configIQE().
+ *
+ * Sample usage:
+ *
+ *     stage("Configure IQE") {
+ *         iqeUtils.configIQE(cciJenkins.configIQEArgs([envName: 'stage_proxy']))
+ *     }
+ *
+ * The defaults herein are derived from iqeUtils.parseOptions().
+ */
+def configIQEArgs(Map args = [:]) {
+    args['extraEnvVars'] = args.get('extraEnvVars', [:])
+    args['settingsFileCredentialsId'] = args.get('settingsFileCredentialsId', false)
+    args['settingsFromGit'] = args.get('settingsFromGit', false)
+    args['vaultEnabled'] = args.get('vaultEnabled', true)
+    args['vaultMountPoint'] = args.get('vaultMountPoint', pipelineVars.defaultVaultMountPoint)
+    args['vaultRoleIdCredential'] = args.get('vaultRoleIdCredential', pipelineVars.defaultVaultRoleIdCredential)
+    args['vaultSecretIdCredential'] = args.get('vaultSecretIdCredential', pipelineVars.defaultVaultSecretIdCredential)
+    args['vaultUrl'] = args.get('vaultUrl', pipelineVars.defaultVaultUrl)
+    args['vaultVerify'] = args.get('vaultVerify', true)
+    return args
+}
+
+/**
+ * Build arguments for iqeUtils.runIQE().
+ *
+ * Sample usage:
+ *
+ *     stage("Run tests") {
+ *         iqeUtils.runIQE("config_manager", cciJenkins.runIQEArgs())
+ *     }
+ *
+ * The defaults herein are derived from iqeUtils.parseOptions().
+ */
+def runIQEArgs(Map args = [:]) {
+    args['browserLog'] = args.get('browserLog', false)
+    args['extraArgs'] = args.get('extraArgs', '')
+    args['filter'] = args.get('filter', '')
+    args['ibutsu'] = args.get('ibutsu', true)
+    args['ibutsuUrl'] = args.get('ibutsuUrl', pipelineVars.defaultIbutsuUrl)
+    args['marker'] = args.get('marker', pipelineVars.defaultMarker)
+    args['netlog'] = args.get('netlog', false)
+    args['reportportal'] = args.get('reportportal', false)
+    args['requirements'] = args.get('requirements', '')
+    args['requirementsPriority'] = args.get('requirementsPriority', '')
+    args['testImportance'] = args.get('testImportance', '')
+    return args
+}

--- a/vars/execIQETests.groovy
+++ b/vars/execIQETests.groovy
@@ -156,18 +156,8 @@ def call(args = [:]) {
     }
 
     if (options['ibutsu']) {
-    // archive an artifact containing the ibutsu URL for this run
         node {
-            writeFile(
-                file: "ibutsu.html",
-                text: (
-                    "<a href=\"https://ibutsu.apps.ocp4.prod.psi.redhat.com/results?" +
-                    "metadata.jenkins.build_number=${env.BUILD_NUMBER}&metadata.jenkins.job_name=" +
-                    "${env.JOB_NAME}\">Click here</a>"
-                )
-            )
-
-            archiveArtifacts "ibutsu.html"
+            iqeUtils.writeIbutsuHtml()
         }
     }
 

--- a/vars/iqeUtils.groovy
+++ b/vars/iqeUtils.groovy
@@ -581,3 +581,18 @@ def prepareStages(Map defaultOptions, Map appConfigs) {
     }
     return stages
 }
+
+/**
+ * Write an ibutsu.html file containing a link to the Ibutsu page with test results.
+ */
+def writeIbutsuHtml() {
+    writeFile(
+        file: "ibutsu.html",
+        text: (
+            "<a href=\"https://ibutsu.apps.ocp4.prod.psi.redhat.com/results" +
+            "?metadata.jenkins.build_number=${env.BUILD_NUMBER}" +
+            "&metadata.jenkins.job_name=${env.JOB_NAME}\">Click here</a>"
+        )
+    )
+    archiveArtifacts "ibutsu.html"
+}


### PR DESCRIPTION
`execIQETests` does the following:

* Potentially execute tests from multiple IQE plugins.
* Dynamically (i.e. at runtime) define job properties and stages.
* Pass functions large maps of arguments.

As a result, defining a job requires running that same job, so that it
can modify itself.

That's *weird*.

This PR adds functions that allow CCI Jenkins to define tests in a more
declarative fashion.

See: https://issues.redhat.com/browse/ESSNTL-1964

See:
https://gitlab.cee.redhat.com/ccit/jenkins-csb/-/blob/main/cci-jd/docs/known-limitations.md#job-properties-triggers-parameters-etc-declared-in-pipeline-are-not-set-before-the-job-is-run