### PR TITLE
make xdist optional

### DIFF
--- a/vars/iqeUtils.groovy
+++ b/vars/iqeUtils.groovy
@@ -108,6 +108,9 @@ private def parseOptions(Map options) {
     options['settingsGitCredentialsId'] = options.get(
         'settingsGitCredentialsId', pipelineVars.gitHttpCreds)
 
+    // enable pytest-xdist plugin for multiprocess parallelism
+    options['xdistEnabled'] = options.get('xdistEnabled', true)
+
     // number of pytest-xdist workers to use for parallel tests
     options['parallelWorkerCount'] = options.get('parallelWorkerCount', 2)
 
@@ -203,6 +206,7 @@ def runIQE(String plugin, Map appOptions) {
     def browserlog = ""
     def reportportalArgs = ""
     def netlog = ""
+    def xdistArgs = ""
 
     if (appOptions['filter']) {
         filterArgs = "-k \"${appOptions['filter']}\""
@@ -234,6 +238,10 @@ def runIQE(String plugin, Map appOptions) {
 
     if (appOptions["netlog"]) {
         netlog = "--netlog"
+    }
+
+    if (appOptions["xdistEnabled"]) {
+        xdistArgs = "-n ${appOptions['parallelWorkerCount']}"
     }
 
     def marker = appOptions['marker']
@@ -285,7 +293,7 @@ def runIQE(String plugin, Map appOptions) {
                     ${requirementsPriorityArgs} \
                     ${testImportanceArgs} \
                     ${extraArgs} \
-                    -n ${appOptions['parallelWorkerCount']} \
+                    ${xdistArgs} \
                     ${ibutsuArgs} \
                     --log-file=iqe-${plugin}-parallel.log \
                     ${browserlog} \


### PR DESCRIPTION
Add a new option to allow disabling the xdist plugin in the test execution. Configured by default to True to ensure the backward compatibility. 

WHY: xdist creates parallelism with multiprocessing, right now this is quite useless because the tests are executed in containers with only one core. Even it could be worse, loosing the benefits of the session scoped fixtures if the code is not prepared for that plugin or adding overhead to the kernel's scheduler. Because the most of the cases this is to test an http application, where the cpu consumption is not the bottleneck but the network IO, it would be more useful implement parallelism based on threads, like does https://github.com/browsertron/pytest-parallel. Anyway, I think it's good making it optional and in my particular case I needed it to avoid a bug with xdist with python 3.8. 

Many plugins can take advantage of this option. 

