### PR TITLE
Update docstring referencing iqeUtils.configIQE()

### DIFF
--- a/vars/cciJenkins.groovy
+++ b/vars/cciJenkins.groovy
@@ -27,7 +27,7 @@
  * Sample usage:
  *
  *     stage("Configure IQE") {
- *         iqeUtils.configIQE(cciJenkins.configIQEArgs([envName: 'stage_proxy']))
+ *         iqeUtils.configIQE("app name", cciJenkins.configIQEArgs([envName: 'stage_proxy']))
  *     }
  *
  * The defaults herein are derived from iqeUtils.parseOptions().


### PR DESCRIPTION
The signature of `iqeUtils.configIQE()` has changed, and now requires an additional parameter.