### PR TITLE
Update iqeUtils.groovy

### DIFF
--- a/vars/iqeUtils.groovy
+++ b/vars/iqeUtils.groovy
@@ -376,11 +376,7 @@ def runIQE(String plugin, Map appOptions) {
 
         // if there were no failures recorded, it's a success
         result = result ?: "SUCCESS"
-
-        if (errorMsgSequential || errorMsgParallel) {
-            error("${errorMsgSequential} ${errorMsgParallel}")
-        }
-
+        
         if (screenshotsDir) {
             dir(screenshotsDir) {
                 archiveArtifacts(
@@ -388,6 +384,10 @@ def runIQE(String plugin, Map appOptions) {
                     allowEmptyArchive: true
                 )
             }
+        }
+
+        if (errorMsgSequential || errorMsgParallel) {
+            error("${errorMsgSequential} ${errorMsgParallel}")
         }
     }
 


### PR DESCRIPTION
Would it be possible to switch the order these two if statements are placed? It happens that because the first one fails, the second does not get executed and may be the reason why we don’t get screenshots on Build Artifacts at a failed Jenkins Job