### PR TITLE
Fix merging default and application options

### DIFF
--- a/vars/iqeUtils.groovy
+++ b/vars/iqeUtils.groovy
@@ -150,9 +150,7 @@ private def mergeAppOptions(Map options, Map appOptions) {
 
     def mergedOptions = [:]
 
-    options.each { key, defaultValue ->
-        mergedOptions[key] = appOptions.get(key, defaultValue)
-    }
+    mergedOptions = options + appOptions
 
     // Support compatibility w/ smoke test syntax which specifies markers as a list of strings
     if (mergedOptions['marker'] instanceof java.util.ArrayList) {


### PR DESCRIPTION
When merging `default options` and `appOptions` currently - we loose key:value pairs that are defined in appOptions but are not in default options.

I caught this when tried to change requestMemory for Compliance here https://github.com/RedHatInsights/iqe-jenkins/commit/bc59a06ccdc9d38ae55f87df7db8563244601d53 . Change is there but it's not taken because we merge config wrongly.