### PR TITLE
Library refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,109 @@ metadata:
   - system:serviceaccount:THE_PROJECT_JENKINS_RUNS_IN:jenkins
 ```
 
+## Usage
+To be able to use insights-pipeline library you need to add it to your jenkins as shared library. Instruction
+is [here](https://www.jenkins.io/doc/book/pipeline/shared-libraries/)
+
+In this repository you can find 2 methods that can be useful for you:
+- **execIQETests** - run IQE tests with passed arguments
+- **execIQETestsWithNotifier** - run IQE tests with passed arguments and send slack notification at the end of run
+
+### What arguments you can pass and what do they mean
+**execIQETests** takes these arguments:
+
+- **appConfigs** - REQUIRED: list of applications and they configs
+  - Example: `["my_app": ["options": ["image": "quay.io/foo/bar:my_image"]]`
+  - **Note** that you app name is only required here
+  - **Note** that list of app options is the same as general options listed below
+- **options** -  REQUIRED: list of options defined for pipeline
+  - **envName** - REQUIRED: name of environment
+    - Example: `stage`
+  - **image** - REQUIRED: the container image that the tests will run with in OpenShift
+    - Example: `quay.io/foo/bar:my_plugin`
+  - **namespace** - OPTIONAL: the namespace that the test pods run in
+    - Example: `'jenkins-csb-insights-qe'`
+  - **cloud** - OPTIONAL: the name of the 'cloud' under the Jenkins kubernetes plugin settings
+    - Example: `'openshift'`
+  - **marker** - OPTIONAL: the pytest marker expression (-m) used when running tests
+    - Example: `'core'`
+  - **filter** - OPTIONAL: the pytest filter expression (-k) used when running tests
+    - Example: `'test_navigation_'`
+  - **requirements** - OPTIONAL: the iqe --requirements expression used when running tests
+    - Example: `'INVENTORY-GROUPS,INVENTORY-SYSTEMS'`
+  - **requirementsPriority** - OPTIONAL: the iqe --requirements-priority expression used when running tests
+    - Example: `'critical,high'`
+  - **testImportance** - OPTIONAL: the iqe --test-importance filter expression used when running tests
+    - Example: `'medium,low'`
+  - **allocateNode** - OPTIONAL: whether or not to spin up a jenkins pod for running the tests
+    - Example: `true`
+  - **reportportal** - OPTIONAL: whether or not to report results to reportportal
+    - Example: `false`
+  - **ibutsu** - OPTIONAL: whether or not to report results to ibutsu
+    - Example: `true`
+  - **ibutsuUrl** - OPTIONAL: the URL of ibutsu
+  - **ui** - OPTIONAL: whether or not to provision a selenium container in the test pod for running UI tests
+    - Set to false by default
+  - **xdistEnabled** OPTIONAL: enable pytest-xdist plugin for multiprocess parallelism
+    - Set to false by default
+    - Set it to true if you have tests that run in parallel with pytest marker @parallel
+    - **Note** that if you want to run tests in parallel you need to have enough memory provided to pods
+  - **parallelWorkerCount** - OPTIONAL: number of pytest-xdist workers to use for parallel tests
+    - Example: `2`
+  - **extraEnvVars** - OPTIONAL: a Map of additional env vars to set in the .env file before running iqe
+    - Example:` ["DYNACONF_MAIN__use_beta": "false"]`
+  - **customPackages** - OPTIONAL: list of custom packages to 'pip install' before tests run
+    - Example: `["iqe-platform-ui-plugin==0.14.23"]`
+  - **extraArgs** - OPTIONAL: extra arguments for plugin tests, i.e. --long-running
+  - **browserlog** - OPTIONAL: collect browser console logs
+    - Example: `true`
+    - It's used for getting more info for debugging
+  - **netlog** - OPTIONAL: collect browser network logs
+    - Example: `true`
+    - It's used for getting more info for debugging
+  - **iqeForceDefaultUser** - OPTIONAL: force iqe to use specific user
+    - Example: `compliance:compliance_testing_user`
+  - **timeout** - OPTIONAL: If pipeline runs more than timeout, jenkins job is killed
+    - Example: `60`
+- **lockName** - OPTIONAL: name of lock for pipeline that will help to avoid running pipelines at the same time
+
+**Note** that you have 2 types of options: application options and global options. App options overwrite global options
+for app specifically. This is made for case when you need to define multiple pipelines run  in parallel. 
+Options affects every pipeline while appConfigs options affect only specific application pipeline.
+
+**execIQETestsWithNotifier** takes same arguments as execIQETests and some additional:
+- **alwaysSendFailureNotification** - OPTIONAL: if true, always send a failure notification
+- **alwaysSendSuccessNotification** - OPTIONAL: if true, always send a success notification
+- **slackUrl** - OPTIONAL: slack integration URL
+- **slackChannel** - REQUIRED: where to report test failures
+- **errorSlackChannel** - REQUIRED: where to report unhandled errors when this job unexpectedly fails
+- **slackMsgCallback** - OPTIONAL: closure to call that generates detailed slack msg text when tests fail
+- **slackSuccessMsgCallback** - OPTIONAL: closure to call that generates detailed slack msg text when tests pass
+- **slackTeamDomain** - OPTIONAL: slack team subdomain
+- **slackTokenCredentialId** - REQUIRED: slack integration token
+- **reqNumBuildsPassBeforeResolved** - OPTIONAL: how many past builds to use before we mark the run as a success
+
+### Example of pipeline definition
+```
+@Library("github.com/RedHatInsights/insights-pipeline-lib@v5") _
+
+def apps = [
+    compliance: [options: [image: "quay.io/cloudservices/iqe-tests:compliance", ui: true]],
+]
+
+def options = [
+    extraEnvVars: ["DYNACONF_MAIN__use_browser":"chrome"],
+    reportportal: true,
+    settingsFromGit: true,
+    timeout: 60,
+    vaultEnabled: true,
+    xdistEnabled: false
+]
+
+execIQETests(
+    appConfigs: apps,
+    envs: ["prod"],
+    defaultMarker: "core",
+    options: options,
+)
+```

--- a/vars/execIQETests.groovy
+++ b/vars/execIQETests.groovy
@@ -1,154 +1,39 @@
 /*
- * This function will do the following:
+ * Function will do the following:
  * - Create a Jenkins job, with checkbox parameters for each 'app' name, text boxes for the pytest
  *     marker and filter expression, and a dropdown parameter to select a different env
  * - Use iqeUtils to run test stages
  * - Return the parallel stage run results to the caller
  *
  * @param appConfigs Map -- see iqeUtils
- * @param envs String[] -- list of environments this test job can run against
  * @param options Map -- see iqeUtils
- * @param defaultMarker String with default marker expression (optional, default is pipelineVars.defaultMarker)
- * @param defaultFilter String for default pytest filter expression (optional)
- * @param requirements String for iqe --requirements expression (optional)
- * @param requirementsPriority String for iqe --requirementsPriority expression (optional)
- * @param testImportance String for iqe --test-importance expression (optional)
- * @param extraJobProperties Array of job properties to append to the properties that this function
- *      creates (optional)
  * @param lockName String the name of the resource to lock (using lockable resources plugin) when
  *      job runs. By default it will be "${envName}-test"
  *
- * @returns Map with format ["success": String[] successStages, "failed": String[] failedStages]
- * @throws AbortException if the 'RELOAD' parameter is true
+ * @return Map with format ["success": String[] successStages, "failed": String[] failedStages]
  */
+
 def call(args = [:]) {
     def appConfigs = args['appConfigs']
-    def envs = args['envs']
     def options = args.get('options', [:])
-    def defaultMarker = args.get('defaultMarker', pipelineVars.defaultMarker)
-    def defaultFilter = args.get('defaultFilter')
-    def requirements = args.get('requirements')
-    def requirementsPriority = args.get('requirementsPriority')
-    def testImportance = args.get('testImportance')
-    def defaultImage = args.get('defaultImage')
-    def extraJobProperties = args.get('extraJobProperties', [])
     def lockName = args.get('lockName')
 
-    p = []
-    // Add a param option for simply reloading this job
-    p.add(
-        [
-            $class: 'BooleanParameterDefinition',
-            name: "RELOAD", defaultValue: false, description: "Reload the job's config and quit"
-        ]
-    )
-
-    // Add a dropdown to select env
-    p.add(
-        [
-            $class: "ChoiceParameterDefinition",
-            name: "env",
-            choices: envs.join("\n"),
-            description: "The target environment to run tests against"
-        ]
-    )
-
-    // Add checkboxes for each app name, checked by default
-    appConfigs.each { appName, appConfig ->
-        p.add(
-            [
-                $class: 'BooleanParameterDefinition',
-                name: appName, defaultValue: true, description: "Run tests for ${appName}"
-            ]
-        )
-    }
-
-    // Add text field for test markers
-    p.add(
-        [
-            $class: 'StringParameterDefinition',
-            name: "marker", defaultValue: defaultMarker != null ? defaultMarker : pipelineVars.defaultMarker,
-            description: "Enter pytest marker expression"
-        ]
-    )
-
-    // Add text field for test filter
-    p.add(
-        [
-            $class: 'StringParameterDefinition',
-            name: "filter", defaultValue: defaultFilter ? defaultFilter : "",
-            description: "Enter pytest filter expression, leave blank for none"
-        ]
-    )
-
-    // Add text field for test filter
-    p.add(
-        [
-            $class: 'StringParameterDefinition',
-            name: "requirements", defaultValue: requirements ? requirements : "",
-            description: "Enter iqe --requirements expression, leave blank for none"
-        ]
-    )
-
-    // Add text field for test filter
-    p.add(
-        [
-            $class: 'StringParameterDefinition',
-            name: "requirementsPriority", defaultValue: requirementsPriority ? requirementsPriority : "",
-            description: "Enter iqe --requirements-priority expression, leave blank for none"
-        ]
-    )
-
-    // Add text field for test filter
-    p.add(
-        [
-            $class: 'StringParameterDefinition',
-            name: "testImportance", defaultValue: testImportance ? testImportance : "",
-            description: "Enter iqe --test-importance expression, leave blank for none"
-        ]
-    )
-
-    // Add text field for test image
-    p.add(
-        [
-            $class: 'StringParameterDefinition',
-            name: "image", defaultValue: defaultImage ? defaultImage : "",
-            description: "Enter the name of the iqe plugin image, leave blank for iqe-core"
-        ]
-    )
-
-    def jobProperties = [parameters(p)]
-    jobProperties.addAll(extraJobProperties)
-
-    properties(jobProperties)
-
-    pipelineUtils.checkForReload()
-
-    // For build #1, only load the pipeline and exit
-    // This is so the next time the job is built, "Build with parameters" will be available
-    if (env.BUILD_NUMBER.toString() == "1") {
-        echo "Initial run, loaded pipeline job and now exiting."
-        currentBuild.description = "loaded params"
-        return
-    }
-
-    // if an app has been unchecked do not run tests for it
-    appConfigs = appConfigs.findAll { params[it.key] == true }
-
-    options['envName'] = params.env
-    options['marker'] = params.marker
-    options['filter'] = params.filter
-    options['requirements'] = params.requirements
-    options['requirementsPriority'] = params.requirementsPriority
-    options['testImportance'] = params.testImportance
-    options['image'] = params.image
+    options['envName'] = options.get('envName', '')
+    options['marker'] = options.get('marker', '')
+    options['namespace'] = options.get('namespace', 'jenkins-csb-insights-qe')
+    options['filter'] = options.get('filter', '')
+    options['requirements'] = options.get('requirements', '')
+    options['requirementsPriority'] = options.get('requirementsPriority', '')
+    options['testImportance'] = options.get('testImportance', '')
+    options['image'] = options.get('image', '')
     options['ibutsu'] = options.get('ibutsu', true)
     options['reportportal'] = options.get('reportportal', false)
     options['cloud'] = options.get('cloud', pipelineVars.upshiftCloud)
     options['timeout'] = options.get('timeout', 150)
+    options['jenkinsSlaveImage'] = options.get('jenkinsSlaveImage', pipelineVars.centralCIjenkinsSlaveImage)
 
     // Run the tests
-    if (!lockName) lockName = "${params.env}-test"
+    if (!lockName) lockName = "${options['envName']}-test"
     lock(lockName) {
         timeout(time: options['timeout'], unit: "MINUTES") {
             results = pipelineUtils.runParallel(iqeUtils.prepareStages(options, appConfigs))

--- a/vars/openShiftUtils.groovy
+++ b/vars/openShiftUtils.groovy
@@ -1,18 +1,6 @@
 // Helpers for spinning up jenkins slaves running on OpenShift and other OpenShift utils
 
-
-def getDefaultSlaveImage(String cloud) {
-    if (cloud.equals(pipelineVars.upshiftCloud)) return pipelineVars.centralCIjenkinsSlaveImage
-    else return pipelineVars.jenkinsSlaveImage
-}
-
-
-def getDefaultSlaveNamespace(String cloud) {
-    if (cloud.equals(pipelineVars.upshiftCloud)) return pipelineVars.upshiftNameSpace
-    else return pipelineVars.defaultNameSpace
-}
-
-
+//TODO check if needed
 private def setDevPiEnvVars(String image, String cloud, Collection envVars) {
     // If using the IQE tests core image on the external OpenShift deployment, use the devpi
     // server deployed in that external cluster
@@ -78,8 +66,8 @@ def withNode(Map parameters = [:], Closure body) {
     */
     def image = parameters.get('image', pipelineVars.iqeCoreImage)
     def cloud = parameters.get('cloud', pipelineVars.defaultCloud)
-    def jenkinsSlaveImage = parameters.get('jenkinsSlaveImage', getDefaultSlaveImage(cloud))
-    def namespace = parameters.get('namespace', getDefaultSlaveNamespace(cloud))
+    def jenkinsSlaveImage = parameters.get('jenkinsSlaveImage', pipelineVars.centralCIjenkinsSlaveImage)
+    def namespace = parameters.get('namespace', pipelineVars.upshiftNameSpace)
     def requestCpu = parameters.get('resourceRequestCpu', "200m")
     def limitCpu = parameters.get('resourceLimitCpu', "500m")
     def requestMemory = parameters.get('resourceRequestMemory', "100Mi")
@@ -153,8 +141,8 @@ def withUINode(Map parameters = [:], Closure body) {
     Spins up a pod with 3 containers: jnlp, selenium, and specified 'image'
     */
     def cloud = parameters.get('cloud', pipelineVars.upshiftCloud)
-    def namespace = parameters.get('namespace', getDefaultSlaveNamespace(cloud))
-    def slaveImage = parameters.get('slaveImage', getDefaultSlaveImage(cloud))
+    def namespace = parameters.get('namespace', pipelineVars.upshiftNameSpace)
+    def slaveImage = parameters.get('slaveImage', pipelineVars.centralCIjenkinsSlaveImage)
     def seleniumImage = parameters.get('seleniumImage', pipelineVars.seleniumImage)
     def image = parameters.get('image', pipelineVars.iqeCoreImage)
     def requestCpu = parameters.get('resourceRequestCpu', "500m")
@@ -254,8 +242,8 @@ def withJnlpNode(Map parameters = [:], Closure body) {
     Spins up a pod with a single jnlp container
     */
     def cloud = parameters.get('cloud', pipelineVars.defaultCloud)
-    def image = parameters.get('image', getDefaultSlaveImage(cloud))
-    def namespace = parameters.get('namespace', getDefaultSlaveNamespace(cloud))
+    def image = parameters.get('image', pipelineVars.centralCIjenkinsSlaveImage)
+    def namespace = parameters.get('namespace', pipelineVars.upshiftNameSpace)
     def jenkinsSvcAccount = parameters.get('jenkinsSvcAccount', pipelineVars.jenkinsSvcAccount)
     def jnlpRequestCpu = parameters.get('jnlpRequestCpu', "100m")
     def jnlpLimitCpu = parameters.get('jnlpLimitCpu', "300m")

--- a/vars/pipelineUtils.groovy
+++ b/vars/pipelineUtils.groovy
@@ -227,13 +227,3 @@ def checkForReload() {
 def throwIfAborted(Exception err) {
     if (currentBuild.result == "ABORTED") throw err
 }
-
-
-def getLastRealBuild(build) {
-    // find the first previous build that is not a 'reload' or 'error' build
-    if (build == null) return null
-    def previousBuild = build.getPreviousBuild()
-    if (previousBuild == null) return null
-    if (previousBuild.description != "reload" && previousBuild.description != "error") return previousBuild
-    else return getLastRealBuild(previousBuild)
-}

--- a/vars/pipelineVars.groovy
+++ b/vars/pipelineVars.groovy
@@ -2,10 +2,8 @@ class pipelineVars implements Serializable {
     String defaultMarker = "core"
 
     String jenkinsSvcAccount = "jenkins"
-    String defaultNameSpace = "jenkins"
 
     String gitSshCreds = "insightsdroid-ssh-git"
-    String gitHttpCreds = "InsightsDroidGitHubHTTP"
 
     String userPath = "~/.local/bin"
     String venvDir = "~/.venv"
@@ -13,8 +11,6 @@ class pipelineVars implements Serializable {
     String smokeTestResourceLabel = "smoke_test_projects"
     String e2eDeployDir = 'e2e-deploy'
     String e2eDeployRepo = 'https://github.com/RedHatInsights/e2e-deploy.git'
-    String jenkinsConfigRepo = 'https://github.com/RedHatInsights/iqe-jenkins.git'
-    String jenkinsConfigDir = 'iqe-jenkins'
     String e2eDeployRepoSsh = 'git@github.com:RedHatInsights/e2e-deploy.git'
     String e2eTestsDir = 'e2e-tests'
     String e2eTestsRepo = 'https://github.com/RedHatInsights/e2e-tests.git'
@@ -29,9 +25,6 @@ class pipelineVars implements Serializable {
     String defaultIbutsuUrl = "https://ibutsu-api.apps.ocp4.prod.psi.redhat.com"
     String defaultIbutsuFrontendUrl = "https://ibutsu.apps.ocp4.prod.psi.redhat.com"
 
-    String jenkinsSlaveImage = (
-        'registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7:v3.11'
-    )
     String centralCIjenkinsSlaveImage = (
         'quay.io/insights-qe/jenkins-slave-base:latest'
     )
@@ -40,9 +33,8 @@ class pipelineVars implements Serializable {
     String seleniumImage = 'quay.io/redhatqe/selenium-standalone:latest'
 
     String defaultCloud = 'openshift'
-    String defaultNamespace = 'jenkins'
     String upshiftCloud = 'upshift'
-    String upshiftNameSpace = 'insights-qe-ci'
+    String upshiftNameSpace = 'jenkins-csb-insights-qe'
 
     String slackDefaultUrl = "https://redhat-internal.slack.com/services/hooks/jenkins-ci/"
     String slackDefaultChannel = '#insights-qe-feed'


### PR DESCRIPTION
Cards that are going to be closed:
- [IQE-2342](https://issues.redhat.com/browse/IQE-2342) Stop depend on iqe-jenkins repository
- [IQE-2343](https://issues.redhat.com/browse/IQE-2343) Remove parameters and reload logic from pipeline library
- [IQE-2345](https://issues.redhat.com/browse/IQE-2345) Make UI and xdist flags false by default
- [IQE-2346](https://issues.redhat.com/browse/IQE-2346) Add option to override default user in execIQETests
- [IQE-2396](https://issues.redhat.com/browse/IQE-2396) Add possibility to provide success pipeline run message

Change list:
- Remove config logic and stop depending on iqe-jenkins repo
- Remove obsolete code
- Support forceDefaultUser to handle user selection
- Add ability to define success message in execIQETestsWithNotifier
- Refactor execIQETestsWithNotifier helper methods
- Correctly return previous build to define if pipeline status changed
- Add piece of doc about using execIQETests
