### PR TITLE
Bugfix: Write env name

### DIFF
--- a/vars/iqeUtils.groovy
+++ b/vars/iqeUtils.groovy
@@ -448,7 +448,7 @@ def writeVaultEnvVars(Map options) {
 
 def configIQE(String appName, Map options) {
     /* Sets up vault and .env files */
-
+    writeEnv('ENV_FOR_DYNACONF', options['envName'])
     writeVaultEnvVars(options)
     options['extraEnvVars'].each { key, value ->
         writeEnv(key, value instanceof Closure ? value(env) : value)


### PR DESCRIPTION
I accidentally deleted part where we write env name when did refactor.