### PR TITLE
Add ibutsu archive to jenkins artifacts

### DIFF
--- a/vars/iqeUtils.groovy
+++ b/vars/iqeUtils.groovy
@@ -374,6 +374,12 @@ def runIQE(String plugin, Map appOptions) {
         }
     }
 
+    // archive Ibutsu artifacts
+    archiveArtifacts(
+        artifacts: "*.tar.gz",
+        allowEmptyArchive: true
+    )
+
     catchError {
         archiveArtifacts "iqe-${plugin}-*.log"
         junit "junit-${plugin}-*.xml"


### PR DESCRIPTION
Let's keep ibutsu archive in Jenkins artifacts too.

Tested locally with csb jenkins:

![image](https://github.com/RedHatInsights/insights-pipeline-lib/assets/33912805/374aa4da-cd70-4b7e-8d64-d38369636bf8)
