### PR TITLE
Disable Session Management Response rule

### DIFF
--- a/vars/rapidastUtils.groovy
+++ b/vars/rapidastUtils.groovy
@@ -157,7 +157,7 @@ def parse_rapidast_options(String ServiceName, String ApiScanner, String TargetU
     data.general.authentication.parameters.client_id = "rhsm-api"
     data.general.authentication.parameters.token_endpoint = pipelineVars.stageSSOUrl
     data.general.container.type = "none"
-    data.scanners.zap.passiveScan.disabledRules = "2,10015,10027,10054,10096,10024"
+    data.scanners.zap.passiveScan.disabledRules = "2,10015,10027,10054,10096,10024,10112"
     data.scanners.zap.miscOptions.oauth2OpenapiManualDownload = true
     //create new with updated YAML config
     writeYaml file: 'config/config.yaml', data: data


### PR DESCRIPTION
Insights responses will always return session ID so this informational alert is not relevant. Note from product security:

Hi Max, IIRC, it is because the 401 response has a Session-cookie whose value looks like a session ID. Could you share an example with me? https://www.zaproxy.org/docs/alerts/10112/. 10112 is just an informational(no severity) rule, so it's totally fine to be disabled. e.g. in the confilg file, set passiveScan.disabledRules like
    passiveScan:
      # Optional comma-separated list of passive rules to disable
      # Use https://www.zaproxy.org/docs/alerts/ to match rule with its ID
      disabledRules: "2,10015,10024,10027,10054,10096,10109,10112"