### PR TITLE
DRAFT: add container mem limit option

### DIFF
--- a/vars/execIQETests.groovy
+++ b/vars/execIQETests.groovy
@@ -31,6 +31,7 @@ def call(args = [:]) {
     options['cloud'] = options.get('cloud', pipelineVars.upshiftCloud)
     options['timeout'] = options.get('timeout', 150)
     options['jenkinsSlaveImage'] = options.get('jenkinsSlaveImage', pipelineVars.centralCIjenkinsSlaveImage)
+    options['limitMemory'] = options.get('resourceLimitMemory', "1Gi")
 
     // Run the tests
     if (!lockName) lockName = "${options['envName']}-test"


### PR DESCRIPTION
Add limitMemory option into execIQETests.groovy so we can increase the mem limit from pipelines which needs that.