### PR TITLE
Use rapidast 2.10.0

### DIFF
--- a/vars/rapidastUtils.groovy
+++ b/vars/rapidastUtils.groovy
@@ -3,7 +3,7 @@
 def slackMessage
 
 def prepareRapidastStages(String ServiceName, String PluginName, String ApiScanner, String TargetUrl, String ApISpecUrl, String Jira, String Cloud=pipelineVars.upshiftCloud, String Namespace=pipelineVars.upshiftNameSpace) {
-    openShiftUtils.withNode(cloud: Cloud, namespace: Namespace, image: 'quay.io/redhatproductsecurity/rapidast:2.7.0-rc1') {
+    openShiftUtils.withNode(cloud: Cloud, namespace: Namespace, image: 'quay.io/redhatproductsecurity/rapidast:2.10.0') {
 
         stage("Set Build Rapidast for ${ServiceName} service") {
              currentBuild.displayName = "#"+ env.BUILD_NUMBER + " " + "${ServiceName}"


### PR DESCRIPTION
This version of rapidast fixes a permissions error which produces messages like:

    Mar 24, 2025 3:27:40 PM java.util.prefs.FileSystemPreferences checkLockFile0ErrorCode
    WARNING: Could not lock User prefs.  Unix error code 2.
    Mar 24, 2025 3:27:40 PM java.util.prefs.FileSystemPreferences syncWorld
    WARNING: Couldn't flush user prefs: java.util.prefs.BackingStoreException: Couldn't get file lock.

See: https://issues.redhat.com/browse/PSSECAUT-1080