### PR TITLE
fix(PSSECAUT-1283): Use rapidast 2.12.1

### DIFF
--- a/vars/rapidastUtils.groovy
+++ b/vars/rapidastUtils.groovy
@@ -3,7 +3,7 @@
 def slackMessage
 
 def prepareRapidastStages(String ServiceName, String PluginName, String ApiScanner, String TargetUrl, String ApISpecUrl, String Jira, String Cloud=pipelineVars.upshiftCloud, String Namespace=pipelineVars.upshiftNameSpace) {
-    openShiftUtils.withNode(cloud: Cloud, namespace: Namespace, image: 'quay.io/redhatproductsecurity/rapidast:2.10.0') {
+    openShiftUtils.withNode(cloud: Cloud, namespace: Namespace, image: 'quay.io/redhatproductsecurity/rapidast:2.12.1') {
 
         stage("Set Build Rapidast for ${ServiceName} service") {
              currentBuild.displayName = "#"+ env.BUILD_NUMBER + " " + "${ServiceName}"


### PR DESCRIPTION
This version should include newer version of ZAP, which will fix this warning from our rapidast pipelines:
```
WARN-NEW: ZAP is Out of Date [10116] x 1
```